### PR TITLE
Switch to Python3

### DIFF
--- a/ArgonCube/TPCActive.py
+++ b/ArgonCube/TPCActive.py
@@ -43,7 +43,7 @@ PixelPlaneCenter = {
         }
 
 # (key/value)-swapped version of TPCActiveID
-TPCActiveCopyNo = {value:key for key, value in TPCActiveID.items()}
+TPCActiveCopyNo = {value:key for key, value in list(TPCActiveID.items())}
 
 def GetTPCActiveCenter(module_copynumber,halfDetector_copynumber):
     return TPCActiveCenter[str(module_copynumber)+str(halfDetector_copynumber)]

--- a/duneggd/Active/MPTECalComponents.py
+++ b/duneggd/Active/MPTECalComponents.py
@@ -48,7 +48,7 @@ class MPTECalTileBuilder(gegede.builder.Builder):
         # first make a mother volume to hold everything else
         dzm = self.depth()
         dzm = dzm/2.0  # Box() requires half dimensions
-        print("dzm=", dzm)
+        print(("dzm=", dzm))
         # shapes need to have a unique name
         name=self.output_name
         tile_shape = geom.shapes.Box(name, self.dx, self.dy, dzm)
@@ -65,7 +65,7 @@ class MPTECalTileBuilder(gegede.builder.Builder):
             lname = (self.output_name+"_L%i" % cntr)
             layer_shape = geom.shapes.Box(lname, self.dx, self.dy, dz/2.0)
             zloc = zloc+skip+dz/2.0
-            print(dz, lspace, mat, zloc)
+            print((dz, lspace, mat, zloc))
             layer_lv = geom.structure.Volume(lname+"_vol", material=mat,
                                              shape=layer_shape)
             if active:
@@ -141,7 +141,7 @@ class MPTECalStripBuilder(gegede.builder.Builder):
 
         # make the mother volume
         name = self.output_name
-        print("In strip builder: strip_length=", strip_length)
+        print(("In strip builder: strip_length=", strip_length))
         strip_shape = geom.shapes.Box(name,
                                       dx=strip_length/2.0,
                                       dy=tile_builder.dy,
@@ -327,7 +327,7 @@ class MPTECalLayerBuilder(gegede.builder.Builder):
         phi_start = self.phi_range[0]+phi_coverage_diff/2.0
 #        phi_end = self.phi_range[1]-phi_coverage_diff/2.0
 #        rmin = self.r
-        print(z_strip, rmin, y_strip, strip_length)
+        print((z_strip, rmin, y_strip, strip_length))
         # figure out outer radius of the mother volume
         # (some euclidean geometry documented in my notes)
         rmax2 = ((z_strip+rmin)**2 + (y_strip/2.0)**2)/Q("1mm**2")
@@ -534,13 +534,13 @@ class MPTECalLayerBuilder(gegede.builder.Builder):
             for y in ys:
                 all_tile_locations.append((x, y))
         ninscribed = len(all_tile_locations)
-        print("number of tiles in inscribed square = %i" % (ninscribed))
+        print(("number of tiles in inscribed square = %i" % (ninscribed)))
         for x, y in new_tile_locations:
             for xx, yy in [(x, y), (x, -y), (y, x), (-y, x)]:
 #                print 'xx, yy = %s , %s' % (xx, yy)
                 all_tile_locations.append((xx, yy))
         nouter = len(all_tile_locations) - ninscribed
-        print('number of tiles outside inscribed square = %i' % (nouter))
+        print(('number of tiles outside inscribed square = %i' % (nouter)))
 
         all_organized=organize_by_rows(all_tile_locations)
         # now build the mother volume
@@ -556,7 +556,7 @@ class MPTECalLayerBuilder(gegede.builder.Builder):
         tname = tile_builder.name
         tile_lv = tile_builder.get_volume()
         for i, yrow in enumerate(all_organized):
-            print('yposition and nx --> %s and %i '%(yrow[0][1],len(yrow))) 
+            print(('yposition and nx --> %s and %i '%(yrow[0][1],len(yrow)))) 
             for j, (x,y) in enumerate(yrow):
 #                print 'placing tile %i_%i at (x,y) = (%s,%s)' % (i, j, x, y)
                 pos = geom.structure.Position(tname+"_%i_%i_pos" % (i, j),
@@ -684,14 +684,14 @@ def organize_by_rows(all_tile_locations):
     temp_array = [all_sorted[0]]
     for x, y in all_sorted[1:]: # loop starting at the second entry
         if y == temp_array[0][1]:
-            print('x == temp_array[0][1] --> %s == %s'%(x, temp_array[0][1]))
-            print('    appending (%s, %s)' % (x, y))
+            print(('x == temp_array[0][1] --> %s == %s'%(x, temp_array[0][1])))
+            print(('    appending (%s, %s)' % (x, y)))
             temp_array.append((x, y))
         else:
             print('appending temp_array')
             all_organized.append(temp_array)
             temp_array = []
-            print('   then appending (%s, %s)' % (x, y))
+            print(('   then appending (%s, %s)' % (x, y)))
             temp_array.append((x, y))
     # loop ends without appending the last temp_array so do it here
     all_organized.append(temp_array)

--- a/duneggd/Active/NDHPgTPC.py
+++ b/duneggd/Active/NDHPgTPC.py
@@ -168,7 +168,7 @@ class NDHPgTPCTempDetElementBuilder(gegede.builder.Builder):
             layer_rot = geom.structure.Rotation(layername+"_rot", y=Q('90deg'))
             layer_pla = geom.structure.Placement(layername+"_pla", volume=layer_lv, pos=layer_pos, rot=layer_rot)
 
-            print( "placing layer", layername, "at position", layerp, "with dimension dX=", layer_shape.dx, "dY=", layer_shape.dy, "and dZ=", layer_shape.dz)
+            print(( "placing layer", layername, "at position", layerp, "with dimension dX=", layer_shape.dx, "dY=", layer_shape.dy, "and dZ=", layer_shape.dz))
 
             tracker_vol.placements.append(layer_pla.name)
 
@@ -236,7 +236,7 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
             Layer_shape = geom.store.shapes.get(Layer_lv.shape)
             layer_thickness = Layer_shape.dz * 2
 
-            print("nLayer ", nlayer, " of type ", type, " have thickness ", layer_thickness)
+            print(("nLayer ", nlayer, " of type ", type, " have thickness ", layer_thickness))
             ecal_barrel_module_thickness += nlayer * layer_thickness
 
         return ecal_barrel_module_thickness
@@ -253,7 +253,7 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
             Layer_shape = geom.store.shapes.get(Layer_lv.shape)
             layer_thickness = Layer_shape.dz * 2
 
-            print("nLayer ", nlayer, " of type ", type, " have thickness ", layer_thickness)
+            print(("nLayer ", nlayer, " of type ", type, " have thickness ", layer_thickness))
             ecal_endcap_module_thickness += nlayer * layer_thickness
 
         return ecal_endcap_module_thickness
@@ -278,7 +278,7 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
         if self.Endcap_Inside == True:
             xpos = self.TPC_halfZ+self.get_ecal_endcap_module_thickness(geom)-(R-h) + safety
 
-        print("PV Endcap put at xpos", xpos)
+        print(("PV Endcap put at xpos", xpos))
 
         return xpos
 
@@ -293,7 +293,7 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
             Layer_shape = geom.store.shapes.get(Layer_lv.shape)
             layer_thickness = Layer_shape.dz * 2
 
-            print("nLayer ", nlayer, " of type ", type, " have thickness ", layer_thickness)
+            print(("nLayer ", nlayer, " of type ", type, " have thickness ", layer_thickness))
             yoke_barrel_module_thickness += nlayer * layer_thickness
 
         return yoke_barrel_module_thickness
@@ -331,17 +331,17 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
             ''' total weight for the 5 coil design is around 93t '''
 
             if self.magnetType == "5Coils":
-                print("Construct Magnet - 5 Coils type with ", self.magnetMaterial, " with a radius of ", self.magnetInnerR, " a thickness of ", self.magnetThickness, " and a length of ", self.magnetHalfLength*2)
+                print(("Construct Magnet - 5 Coils type with ", self.magnetMaterial, " with a radius of ", self.magnetInnerR, " a thickness of ", self.magnetThickness, " and a length of ", self.magnetHalfLength*2))
                 nCoils = 5
                 CoilWidth = [Q("27cm"), Q("61.6cm"), Q("27cm"), Q("61.6cm"), Q("27cm")]
                 CoilPos = [Q("-5.5m"), Q("-3m"), Q("0m"), Q("3m"), Q("5.5m")]
             if self.magnetType == "4Coils":
-                print("Construct Magnet - 4 Coils type with ", self.magnetMaterial, " with a radius of ", self.magnetInnerR, " a thickness of ", self.magnetThickness, " and a length of ", self.magnetHalfLength*2)
+                print(("Construct Magnet - 4 Coils type with ", self.magnetMaterial, " with a radius of ", self.magnetInnerR, " a thickness of ", self.magnetThickness, " and a length of ", self.magnetHalfLength*2))
                 nCoils = 4
                 CoilWidth = [Q("27cm"), Q("61.6cm"), Q("61.6cm"), Q("27cm")]
                 CoilPos = [Q("-5.5m"), Q("-3m"), Q("3m"), Q("5.5m")]
             if self.magnetType == "2Coils":
-                print("Construct Magnet - 2 Coils type with ", self.magnetMaterial, " with a radius of ", self.magnetInnerR, " a thickness of ", self.magnetThickness, " and a length of ", self.magnetHalfLength*2)
+                print(("Construct Magnet - 2 Coils type with ", self.magnetMaterial, " with a radius of ", self.magnetInnerR, " a thickness of ", self.magnetThickness, " and a length of ", self.magnetHalfLength*2))
                 nCoils = 2
                 CoilWidth = [Q("61.6cm"), Q("61.6cm")]
                 CoilPos = [Q("-3m"), Q("3m")]
@@ -371,7 +371,7 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
             ''' The PRY covers only +/- 30 deg up and down the MPD and has a bore of 3.5m'''
             ''' Total weight is ~XXXt '''
 
-            print("Construct Magnet SPY - Solenoid made of ", self.magnetMaterial, " with a radius of ", self.magnetInnerR, " a thickness of ", self.magnetThickness, " and a length of ", self.magnetHalfLength*2)
+            print(("Construct Magnet SPY - Solenoid made of ", self.magnetMaterial, " with a radius of ", self.magnetInnerR, " a thickness of ", self.magnetThickness, " and a length of ", self.magnetHalfLength*2))
 
             nCoils = 4
             CoilWidth = Q("1496mm")
@@ -397,7 +397,7 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
             self.add_volume(magnet_vol)
 
         elif self.magnetType == "Uniform":
-            print("Construct Magnet - Approximation to a magnet of 100t made of ", self.magnetMaterial, " with a radius of ", self.magnetInnerR, " a thickness of ", self.magnetThickness, " and a length of ", self.magnetHalfLength*2)
+            print(("Construct Magnet - Approximation to a magnet of 100t made of ", self.magnetMaterial, " with a radius of ", self.magnetInnerR, " a thickness of ", self.magnetThickness, " and a length of ", self.magnetHalfLength*2))
 
             magnet_name = self.output_name
             magnet_shape = geom.shapes.Tubs(magnet_name, rmin=self.magnetInnerR, rmax=self.magnetInnerR+self.magnetThickness, dz=self.magnetHalfLength, sphi="0deg", dphi="360deg")
@@ -441,7 +441,7 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
         R = q/(2*h/Q("1mm"))*Q("1mm")
         dtheta = asin( 2*(h/Q("1mm"))*(x/Q("1mm"))/q)
 
-        print("h, x, q, R, dtheta = ", h, x, q, R, dtheta)
+        print(("h, x, q, R, dtheta = ", h, x, q, R, dtheta))
 
         pvec_name = self.output_name + "Endcap"
         pvec_shape = geom.shapes.Sphere(pvec_name, rmin=R, rmax=R + self.pvThickness, sphi="0deg", dphi="360deg", stheta="0deg", dtheta=dtheta)
@@ -477,19 +477,19 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
         ecal_barrel_module_thickness_noSupport = ecal_barrel_module_thickness - safety
         #inner radius ecal (TPC + pv + safety)
         rInnerEcal = self.rInnerTPC + self.pvThickness
-        print("Ecal inner radius ", rInnerEcal)
+        print(("Ecal inner radius ", rInnerEcal))
         #barrel length (TPC + PV)
         Barrel_halfZ = self.get_pv_endcap_length(geom)
         if self.Endcap_Inside == True:
             Barrel_halfZ = self.TPC_halfZ + self.get_ecal_endcap_module_thickness(geom)
         #outer radius ecal (inner radius ecal + ecal module)
         rOuterEcal = rInnerEcal + ecal_barrel_module_thickness
-        print("Ecal outer radius ", rOuterEcal)
+        print(("Ecal outer radius ", rOuterEcal))
         #check that the ECAL thickness does not go over the magnet radius
         ecal_barrel_module_thickness_max = self.magnetInnerR * cos(pi/nsides) - rInnerEcal
 
-        print("Barrel Module thickness ", ecal_barrel_module_thickness)
-        print("Maximum allowed thickness ", ecal_barrel_module_thickness_max)
+        print(("Barrel Module thickness ", ecal_barrel_module_thickness))
+        print(("Maximum allowed thickness ", ecal_barrel_module_thickness_max))
 
         if ecal_barrel_module_thickness > ecal_barrel_module_thickness_max:
             print("Will have overlaps if the magnet is present!")
@@ -504,12 +504,12 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
         #dimension of a module along the ND x direction
         Ecal_Barrel_module_dim = Ecal_Barrel_halfZ * 2 / Ecal_Barrel_n_modules
 
-        print("Large side of the stave", max_dim_stave)
-        print("Small side of the stave", min_dim_stave)
-        print("Barrel module dim in z", Ecal_Barrel_module_dim)
-        print("Build Thinner Upstream ECAL", self.buildThinUpstream)
+        print(("Large side of the stave", max_dim_stave))
+        print(("Small side of the stave", min_dim_stave))
+        print(("Barrel module dim in z", Ecal_Barrel_module_dim))
+        print(("Build Thinner Upstream ECAL", self.buildThinUpstream))
         if self.buildThinUpstream:
-            print("Number of layers for the Upstream ECAL", self.nLayers_Upstream)
+            print(("Number of layers for the Upstream ECAL", self.nLayers_Upstream))
 
         #Position of the stave in the Barrel (local coordinates)
         X = rInnerEcal + safety + ecal_barrel_module_thickness / 2.
@@ -533,11 +533,11 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
             if placing_angle >= 360:
                 placing_angle = placing_angle - 360
 
-            print("Placing stave ", stave_id, " at angle ", placing_angle, " deg")
+            print(("Placing stave ", stave_id, " at angle ", placing_angle, " deg"))
 
             for imodule in range(Ecal_Barrel_n_modules):
                 module_id = imodule+1
-                print("Placing stave ", stave_id, " and module ", module_id)
+                print(("Placing stave ", stave_id, " and module ", module_id))
 
                 stave_name = self.output_name + "_stave%02i" % (stave_id) + "_module%02i" % (module_id)
                 stave_volname = self.output_name + "_stave%02i" % (stave_id) + "_module%02i" % (module_id) + "_vol"
@@ -643,8 +643,8 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
             rmin = EcalEndcap_inner_radius
             rmax = EcalEndcap_outer_radius + 2*safety
 
-            print("Quadrant side ", rmax)
-            print("Endcap thickness ", ecal_endcap_module_thickness)
+            print(("Quadrant side ", rmax))
+            print(("Endcap thickness ", ecal_endcap_module_thickness))
 
             #Mother volume Endcap
             endcap_shape_min = geom.shapes.PolyhedraRegular("ECALEndcap_min", numsides=nsides, rmin=rmin, rmax=rmax, dz=EcalEndcap_min_z)
@@ -684,7 +684,7 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
                     else:
                         this_module_rotZ = rotZ_offset + (iquad+1) * pi/2.
 
-                    print("Placing stave ", stave_id, " and module ", module_id)
+                    print(("Placing stave ", stave_id, " and module ", module_id))
 
                     #Create a template module
                     stave_name = self.output_name + "_stave%02i" % (stave_id) + "_module%02i" % (module_id)
@@ -745,8 +745,8 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
             rmin = EcalEndcap_inner_radius
             rmax = EcalEndcap_outer_radius
 
-            print("Quadrant side ", rmax)
-            print("Endcap thickness ", ecal_endcap_module_thickness)
+            print(("Quadrant side ", rmax))
+            print(("Endcap thickness ", ecal_endcap_module_thickness))
 
             #Mother volume Endcap
             endcap_shape_min = geom.shapes.Tubs("ECALEndcap_min", rmin=rmin, rmax=rmax, dz=EcalEndcap_min_z, sphi="0deg", dphi="360deg")
@@ -786,7 +786,7 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
                     else:
                         this_module_rotZ = rotZ_offset + (iquad+1) * pi/2.
 
-                    print("Placing stave ", stave_id, " and module ", module_id)
+                    print(("Placing stave ", stave_id, " and module ", module_id))
 
                     #Create a template module
                     stave_name = self.output_name + "_stave%02i" % (stave_id) + "_module%02i" % (module_id)
@@ -848,8 +848,8 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
             YokeEndcap_min_z = self.TPC_halfZ + self.get_ecal_endcap_module_thickness(geom) + self.pvEndCapBulge + safety
             YokeEndcap_max_z = YokeEndcap_min_z + yoke_barrel_thickness + safety
 
-        print("Construct PRY made of ", self.PRYMaterial, " with a radius of ", rmin_barrel, " a thickness of ", yoke_barrel_thickness, " and a length of ", YokeEndcap_min_z*2)
-        print("Build integrated Muon ID ", self.IntegratedMuID)
+        print(("Construct PRY made of ", self.PRYMaterial, " with a radius of ", rmin_barrel, " a thickness of ", yoke_barrel_thickness, " and a length of ", YokeEndcap_min_z*2))
+        print(("Build integrated Muon ID ", self.IntegratedMuID))
 
         '''Barrel'''
         byoke_name = "YokeBarrel"
@@ -894,16 +894,16 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
             #nsides = 16 -> stave 4,5,6
             set_stave = set(self.yoke_stave_to_remove)
             if stave_id in set_stave:
-                print("Ignoring stave", stave_id)
+                print(("Ignoring stave", stave_id))
                 continue
 
             # if stave_id > 2: continue
 
-            print("Placing stave ", stave_id, " at angle ", placing_angle, " deg")
+            print(("Placing stave ", stave_id, " at angle ", placing_angle, " deg"))
 
             for imodule in range(Yoke_Barrel_n_modules):
                 module_id = imodule+1
-                print("Placing stave ", stave_id, " and module ", module_id)
+                print(("Placing stave ", stave_id, " and module ", module_id))
 
                 stave_name = byoke_name + "_stave%02i" % (stave_id) + "_module%02i" % (module_id)
                 stave_volname = byoke_name + "_stave%02i" % (stave_id) + "_module%02i" % (module_id) + "_vol"
@@ -922,7 +922,7 @@ class NDHPgTPCDetElementBuilder(gegede.builder.Builder):
 
                             layername = byoke_name + "_stave%02i" % (stave_id) + "_module%02i" % (module_id) + "_layer_%02i" % (layer_id)
 
-                            print("Adding ", layername)
+                            print(("Adding ", layername))
 
                             #Configure the layer length based on the zPos in the stave
                             Layer_builder = self.get_builder(type)

--- a/duneggd/Active/NDHPgTPC_SPYv3.py
+++ b/duneggd/Active/NDHPgTPC_SPYv3.py
@@ -188,7 +188,7 @@ class NDHPgTPC_SPYv3_DetElementBuilder(gegede.builder.Builder):
             Layer_shape = geom.store.shapes.get(Layer_lv.shape)
             layer_thickness = Layer_shape.dz * 2
 
-            print("nLayer ", nlayer, " of type ", type, " have thickness ", layer_thickness)
+            print(("nLayer ", nlayer, " of type ", type, " have thickness ", layer_thickness))
             ecal_barrel_module_thickness += nlayer * layer_thickness
 
         return ecal_barrel_module_thickness
@@ -205,7 +205,7 @@ class NDHPgTPC_SPYv3_DetElementBuilder(gegede.builder.Builder):
             Layer_shape = geom.store.shapes.get(Layer_lv.shape)
             layer_thickness = Layer_shape.dz * 2
 
-            print("nLayer ", nlayer, " of type ", type, " have thickness ", layer_thickness)
+            print(("nLayer ", nlayer, " of type ", type, " have thickness ", layer_thickness))
             ecal_endcap_module_thickness += nlayer * layer_thickness
 
         return ecal_endcap_module_thickness
@@ -227,7 +227,7 @@ class NDHPgTPC_SPYv3_DetElementBuilder(gegede.builder.Builder):
             Layer_shape = geom.store.shapes.get(Layer_lv.shape)
             layer_thickness = Layer_shape.dz * 2
 
-            print("nLayer ", nlayer, " of type ", type, " have thickness ", layer_thickness)
+            print(("nLayer ", nlayer, " of type ", type, " have thickness ", layer_thickness))
             yoke_barrel_module_thickness += nlayer * layer_thickness
 
         return yoke_barrel_module_thickness
@@ -255,14 +255,14 @@ class NDHPgTPC_SPYv3_DetElementBuilder(gegede.builder.Builder):
         ''' construct the Cryostat hosting the coils '''
         safety = Q("1mm")
 
-        print("Construct Cryostat, Inner Radius: ", self.CryostatInnerR, " Outer Radius: ", self.CryostatOuterR, " Thickness Inner ", self.CryostatThicknessInner, " Length ", self.CryostatHalfLength*2)
+        print(("Construct Cryostat, Inner Radius: ", self.CryostatInnerR, " Outer Radius: ", self.CryostatOuterR, " Thickness Inner ", self.CryostatThicknessInner, " Length ", self.CryostatHalfLength*2))
 
         ''' Fake shape filled with Air to contain the coils '''
         cryostat_name = self.output_name
         cryostat_shape = geom.shapes.Tubs(cryostat_name, rmin=self.CryostatInnerR, rmax=self.CryostatOuterR, dz=self.CryostatHalfLength, sphi="0deg", dphi="360deg")
         cryostat_vol = geom.structure.Volume("vol"+cryostat_name, shape=cryostat_shape, material="Air")
 
-        for ncoil, coilp in zip(range(len(self.CoilsPos)), self.CoilsPos):
+        for ncoil, coilp in zip(list(range(len(self.CoilsPos))), self.CoilsPos):
             coil_name = self.output_name + "_Coil%01i" % ncoil
             coil_shape = geom.shapes.Tubs(coil_name, rmin=self.CoilInnerR, rmax=self.CoilInnerR+self.CoilThickness, dz=self.CoilWidth/2., sphi="0deg", dphi="360deg")
             coil_vol = geom.structure.Volume("vol"+coil_name, shape=coil_shape, material=self.CoilMaterial)
@@ -348,18 +348,18 @@ class NDHPgTPC_SPYv3_DetElementBuilder(gegede.builder.Builder):
         ecal_barrel_module_thickness_noSupport = ecal_barrel_module_thickness - safety
         #inner radius ecal (TPC + pv + safety)
         rInnerEcal = self.rInnerTPC
-        print("Ecal inner radius ", rInnerEcal)
+        print(("Ecal inner radius ", rInnerEcal))
         #barrel length (Up to the cryostat minus 15 cm)
         Barrel_halfZ = self.CryostatHalfLength - self.ECALCryostatSpace
         
         #outer radius ecal (inner radius ecal + ecal module)
         rOuterEcal = rInnerEcal + ecal_barrel_module_thickness
-        print("Ecal outer radius ", rOuterEcal)
+        print(("Ecal outer radius ", rOuterEcal))
         #check that the ECAL thickness does not go over the magnet radius
         ecal_barrel_module_thickness_max = self.CryostatInnerR * cos(pi/nsides) - rInnerEcal
 
-        print("Barrel Module thickness ", ecal_barrel_module_thickness)
-        print("Maximum allowed thickness ", ecal_barrel_module_thickness_max)
+        print(("Barrel Module thickness ", ecal_barrel_module_thickness))
+        print(("Maximum allowed thickness ", ecal_barrel_module_thickness_max))
 
         if ecal_barrel_module_thickness > ecal_barrel_module_thickness_max:
             print("Will have overlaps if the magnet is present!")
@@ -374,12 +374,12 @@ class NDHPgTPC_SPYv3_DetElementBuilder(gegede.builder.Builder):
         #dimension of a module along the ND x direction
         Ecal_Barrel_module_dim = Ecal_Barrel_halfZ * 2 / Ecal_Barrel_n_modules
 
-        print("Large side of the stave", max_dim_stave)
-        print("Small side of the stave", min_dim_stave)
-        print("Barrel module dim in z", Ecal_Barrel_module_dim)
-        print("Build Thinner Upstream ECAL", self.buildThinUpstream)
+        print(("Large side of the stave", max_dim_stave))
+        print(("Small side of the stave", min_dim_stave))
+        print(("Barrel module dim in z", Ecal_Barrel_module_dim))
+        print(("Build Thinner Upstream ECAL", self.buildThinUpstream))
         if self.buildThinUpstream:
-            print("Number of layers for the Upstream ECAL", self.nLayers_Upstream)
+            print(("Number of layers for the Upstream ECAL", self.nLayers_Upstream))
 
         #Position of the stave in the Barrel (local coordinates)
         X = rInnerEcal + safety + ecal_barrel_module_thickness / 2.
@@ -403,11 +403,11 @@ class NDHPgTPC_SPYv3_DetElementBuilder(gegede.builder.Builder):
             if placing_angle >= 360:
                 placing_angle = placing_angle - 360
 
-            print("Placing stave ", stave_id, " at angle ", placing_angle, " deg")
+            print(("Placing stave ", stave_id, " at angle ", placing_angle, " deg"))
 
             for imodule in range(Ecal_Barrel_n_modules):
                 module_id = imodule+1
-                print("Placing stave ", stave_id, " and module ", module_id)
+                print(("Placing stave ", stave_id, " and module ", module_id))
 
                 stave_name = self.output_name + "_stave%02i" % (stave_id) + "_module%02i" % (module_id)
                 stave_volname = self.output_name + "_stave%02i" % (stave_id) + "_module%02i" % (module_id) + "_vol"
@@ -507,8 +507,8 @@ class NDHPgTPC_SPYv3_DetElementBuilder(gegede.builder.Builder):
         rmin = EcalEndcap_inner_radius
         rmax = EcalEndcap_outer_radius
 
-        print("Quadrant side ", rmax)
-        print("Endcap thickness ", ecal_endcap_module_thickness)
+        print(("Quadrant side ", rmax))
+        print(("Endcap thickness ", ecal_endcap_module_thickness))
 
         #Mother volume Endcap
         endcap_shape_min = geom.shapes.Tubs("ECALEndcap_min", rmin=rmin, rmax=rmax, dz=EcalEndcap_min_z, sphi="0deg", dphi="360deg")
@@ -548,7 +548,7 @@ class NDHPgTPC_SPYv3_DetElementBuilder(gegede.builder.Builder):
                 else:
                     this_module_rotZ = rotZ_offset + (iquad+1) * pi/2.
 
-                print("Placing stave ", stave_id, " and module ", module_id)
+                print(("Placing stave ", stave_id, " and module ", module_id))
 
                 #Create a template module
                 stave_name = self.output_name + "_stave%02i" % (stave_id) + "_module%02i" % (module_id)
@@ -607,8 +607,8 @@ class NDHPgTPC_SPYv3_DetElementBuilder(gegede.builder.Builder):
         YokeEndcap_min_z = self.CryostatHalfLength + self.CryostatThicknessEndcap + safety
         YokeEndcap_max_z = YokeEndcap_min_z + self.yokeThicknessEndcap + safety
 
-        print("Construct PRY made of ", self.PRYMaterial, " with a radius of ", rmin_barrel, " a thickness of ", yoke_barrel_thickness, " and a length of ", YokeEndcap_min_z*2)
-        print("Build integrated Muon ID ", self.IntegratedMuID)
+        print(("Construct PRY made of ", self.PRYMaterial, " with a radius of ", rmin_barrel, " a thickness of ", yoke_barrel_thickness, " and a length of ", YokeEndcap_min_z*2))
+        print(("Build integrated Muon ID ", self.IntegratedMuID))
 
         '''Barrel'''
         byoke_name = "YokeBarrel"
@@ -653,16 +653,16 @@ class NDHPgTPC_SPYv3_DetElementBuilder(gegede.builder.Builder):
             #nsides = 16 -> stave 4,5,6
             set_stave = set(self.yoke_stave_to_remove)
             if stave_id in set_stave:
-                print("Ignoring stave", stave_id)
+                print(("Ignoring stave", stave_id))
                 continue
 
             # if stave_id > 2: continue
 
-            print("Placing stave ", stave_id, " at angle ", placing_angle, " deg")
+            print(("Placing stave ", stave_id, " at angle ", placing_angle, " deg"))
 
             for imodule in range(Yoke_Barrel_n_modules):
                 module_id = imodule+1
-                print("Placing stave ", stave_id, " and module ", module_id)
+                print(("Placing stave ", stave_id, " and module ", module_id))
 
                 stave_name = byoke_name + "_stave%02i" % (stave_id) + "_module%02i" % (module_id)
                 stave_volname = byoke_name + "_stave%02i" % (stave_id) + "_module%02i" % (module_id) + "_vol"
@@ -681,7 +681,7 @@ class NDHPgTPC_SPYv3_DetElementBuilder(gegede.builder.Builder):
 
                             layername = byoke_name + "_stave%02i" % (stave_id) + "_module%02i" % (module_id) + "_layer_%02i" % (layer_id)
 
-                            print("Adding ", layername)
+                            print(("Adding ", layername))
 
                             #Configure the layer length based on the zPos in the stave
                             Layer_builder = self.get_builder(type)

--- a/duneggd/ArgonCube/ArCLight.py
+++ b/duneggd/ArgonCube/ArCLight.py
@@ -72,7 +72,7 @@ class ArCLightBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('ArCLightBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Construct WLS panel

--- a/duneggd/ArgonCube/Backplate.py
+++ b/duneggd/ArgonCube/Backplate.py
@@ -51,7 +51,7 @@ class BackplateBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('BackplateBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Construct Backplate Gap Volume

--- a/duneggd/ArgonCube/Bucket.py
+++ b/duneggd/ArgonCube/Bucket.py
@@ -70,7 +70,7 @@ class BucketBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('BucketBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Construct G10 Side Volume

--- a/duneggd/ArgonCube/Detector.py
+++ b/duneggd/ArgonCube/Detector.py
@@ -38,7 +38,7 @@ class DetectorBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('DetectorBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Build Module

--- a/duneggd/ArgonCube/Feedthrough.py
+++ b/duneggd/ArgonCube/Feedthrough.py
@@ -61,7 +61,7 @@ class FeedthroughBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('FeedthroughBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Construct FlangePart Volume

--- a/duneggd/ArgonCube/Flange.py
+++ b/duneggd/ArgonCube/Flange.py
@@ -67,7 +67,7 @@ class FlangeBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('FlangeBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Construct FlangeTop Volume

--- a/duneggd/ArgonCube/HVFeedThrough.py
+++ b/duneggd/ArgonCube/HVFeedThrough.py
@@ -40,7 +40,7 @@ class HVFeedThroughBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Tubs')
         print('HVFeedThroughBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Construct Insulation Volume

--- a/duneggd/ArgonCube/HalfDetector.py
+++ b/duneggd/ArgonCube/HalfDetector.py
@@ -48,7 +48,7 @@ class HalfDetectorBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('HalfDetectorBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Construct Fieldcage

--- a/duneggd/ArgonCube/InnerDetector.py
+++ b/duneggd/ArgonCube/InnerDetector.py
@@ -33,7 +33,7 @@ class InnerDetectorBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('InnerDetectorBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Build HalfDetector L

--- a/duneggd/ArgonCube/LCM.py
+++ b/duneggd/ArgonCube/LCM.py
@@ -69,7 +69,7 @@ class LCMBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('LCMBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Construct Fiber TPB layer

--- a/duneggd/ArgonCube/LCMPlane.py
+++ b/duneggd/ArgonCube/LCMPlane.py
@@ -39,7 +39,7 @@ class LCMPlaneBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('LCMPlaneBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Build ArCLight Array

--- a/duneggd/ArgonCube/Module.py
+++ b/duneggd/ArgonCube/Module.py
@@ -36,7 +36,7 @@ class ModuleBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('ModuleBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Build Bucket

--- a/duneggd/ArgonCube/ModuleArray.py
+++ b/duneggd/ArgonCube/ModuleArray.py
@@ -35,7 +35,7 @@ class ModuleArrayBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('ModuleArrayBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Build Array

--- a/duneggd/ArgonCube/NDBucket.py
+++ b/duneggd/ArgonCube/NDBucket.py
@@ -43,7 +43,7 @@ class NDBucketBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('NDBucketBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Construct a rectangular column of LAr that everything sits inside

--- a/duneggd/ArgonCube/NDTop.py
+++ b/duneggd/ArgonCube/NDTop.py
@@ -24,7 +24,7 @@ class FullTopBuilder(gegede.builder.Builder):
                                 'dz':   self.top_sep*self.N_Top/2+self.top_builder.halfDimension['dz']}
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('DetectorBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
         W=int((self.N_Top-1)/2)  #pick odd number
 
@@ -49,7 +49,7 @@ class TopBuilder(gegede.builder.Builder):
                               'dz':   self.tub_builder.halfDimension['dz']}
         main_lv, main_hDim = ltools.main_lv(self, geom, 'Box')
         print('DetectorBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         pos = [-self.halfDimension['dx']+self.grating_builder.halfDimension['dx'],Q('0cm'), Q('0cm')]
@@ -85,7 +85,7 @@ class GratingBuilder(gegede.builder.Builder):#could stand to add square holes in
                               'dz':   self.topgrating_z/2}
         main_lv, main_hDim = ltools.main_lv(self, geom, 'Box')
         print('DetectorBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         gratingshape = geom.shapes.Box(None, self.gratingthick/2, self.halfDimension['dy'], self.halfDimension['dz'])
@@ -131,7 +131,7 @@ class SupportBuilder(gegede.builder.Builder):   #could stand to put in grating p
                               'dz':   self.botgrating_dim/2}
         main_lv, main_hDim = ltools.main_lv(self, geom, 'Box')
         print('DetectorBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
         cs = Q("1.6in") #center to side of tri
         base_shape =geom.shapes.PolyhedraRegular(None, 3,Q("0deg"),Q("360deg"),Q("0m"),cs,self.halfDimension['dx']-self.gratingthick/2)#the 1.6 is arbitrary for now
@@ -187,7 +187,7 @@ class TubBuilder(gegede.builder.Builder):
                               'dz':   self.tub_z/2}
         main_lv, main_hDim = ltools.main_lv(self, geom, 'Box')
         print('DetectorBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         botplatepos = [ -self.halfDimension['dx']+self.tubthick/2,Q('0cm'),Q('0cm')]
@@ -309,7 +309,7 @@ class FlangesBuilder(gegede.builder.Builder):
                              'dz':   self.bigplate_z/2}
         main_lv, main_hDim = ltools.main_lv(self, geom, 'Box')
         print('DetectorBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         platepos = [-self.halfDimension['dx']+self.plate_x/2,Q('0cm'), Q('0cm')]
@@ -473,7 +473,7 @@ class CapCylBuilder(gegede.builder.Builder):
                               'dz':   self.capOD/2}
         main_lv, main_hDim = ltools.main_lv(self, geom, 'Box')
         print('DetectorBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         tubs0=geom.shapes.Tubs(None,self.cylID/2,self.cylOD/2,self.cyl_x/2, Q("0deg"),Q("360deg"))
@@ -514,7 +514,7 @@ class BeamBuilder(gegede.builder.Builder):
                               'dz':   self.lipsize/2}
         main_lv, main_hDim = ltools.main_lv(self, geom, 'Box')
         print('DetectorBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
         toplippos = [-self.halfDimension['dx']+self.lipthick/2,Q('0cm'), Q('0cm')]
         botlippos = [self.halfDimension['dx']-self.lipthick/2,Q('0cm'), Q('0cm')]
@@ -554,7 +554,7 @@ class CrossBeamBuilder(gegede.builder.Builder):
                               'dz':   self.lipsize/2}
         main_lv, main_hDim = ltools.main_lv(self, geom, 'Box')
         print('DetectorBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
         toplippos = [-self.halfDimension['dx']+self.lipthick/2,Q('0cm'), Q('0cm')]
         botlippos = [self.halfDimension['dx']-self.lipthick/2,Q('0cm'), Q('0cm')]

--- a/duneggd/ArgonCube/OptSim.py
+++ b/duneggd/ArgonCube/OptSim.py
@@ -51,7 +51,7 @@ class OptSimBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('OptSimBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Construct Fieldcage

--- a/duneggd/ArgonCube/OpticalDet.py
+++ b/duneggd/ArgonCube/OpticalDet.py
@@ -43,7 +43,7 @@ class OpticalDetBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('OpticalDetBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Build ArCLight Array

--- a/duneggd/ArgonCube/OpticalDetL.py
+++ b/duneggd/ArgonCube/OpticalDetL.py
@@ -44,7 +44,7 @@ class OpticalDetLBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('OpticalDetLBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Build ArCLight Array

--- a/duneggd/ArgonCube/OpticalDetR.py
+++ b/duneggd/ArgonCube/OpticalDetR.py
@@ -44,7 +44,7 @@ class OpticalDetRBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('OpticalDetRBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Build ArCLight Array

--- a/duneggd/ArgonCube/Pillow.py
+++ b/duneggd/ArgonCube/Pillow.py
@@ -62,7 +62,7 @@ class PillowBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('PillowBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Construct Pillow Side Volume

--- a/duneggd/ArgonCube/PixelPlane.py
+++ b/duneggd/ArgonCube/PixelPlane.py
@@ -54,7 +54,7 @@ class PixelPlaneBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('PixelPlaneBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Construct PCB panel

--- a/duneggd/ArgonCube/TPC.py
+++ b/duneggd/ArgonCube/TPC.py
@@ -39,7 +39,7 @@ class TPCBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('TPCBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Build TPCPlane

--- a/duneggd/ArgonCube/TPCPlane.py
+++ b/duneggd/ArgonCube/TPCPlane.py
@@ -38,7 +38,7 @@ class TPCPlaneBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('TPCPlaneBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Build TPC Array

--- a/duneggd/ArgonCube/TPiece.py
+++ b/duneggd/ArgonCube/TPiece.py
@@ -49,7 +49,7 @@ class TPieceBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Box')
         print('TPieceBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Construct TubeV Volume

--- a/duneggd/Component/Plane.py
+++ b/duneggd/Component/Plane.py
@@ -45,7 +45,7 @@ class SBPlaneBuilder(gegede.builder.Builder):
         # Place the bars in the plane
         nScintBarsPerPlane = int(math.floor((self.SBPlaneDim[0]/self.ScintBarDim[0])))
         if self.nScintBars != nScintBarsPerPlane:
-           print( 'SBPlaneBuilder: making'+str(nScintBarsPerPlane)+' scintillator bars per plane, should be '+str(self.nScintBars))
+           print(( 'SBPlaneBuilder: making'+str(nScintBarsPerPlane)+' scintillator bars per plane, should be '+str(self.nScintBars)))
   
         for i in range(nScintBarsPerPlane):
             xpos = -0.5*self.SBPlaneDim[0] + (i+0.5)*self.ScintBarDim[0]

--- a/duneggd/Component/RPCMod.py
+++ b/duneggd/Component/RPCMod.py
@@ -47,8 +47,8 @@ class RPCModBuilder(gegede.builder.Builder):
         nXStrips = int(self.resiplateDim[0]/self.stripxDim[0])
         nYStrips = int(self.resiplateDim[1]/self.stripyDim[1])
 
-        print( 'RPCModBuilder: '+ str(nXStrips) +' X-Strips per RPC ')
-        print( 'RPCModBuilder: '+ str(nYStrips) +' Y-Strips per RPC ')
+        print(( 'RPCModBuilder: '+ str(nXStrips) +' X-Strips per RPC '))
+        print(( 'RPCModBuilder: '+ str(nYStrips) +' Y-Strips per RPC '))
 
         # for loop to position and place X strips in RPCMod
         for i in range(nXStrips):

--- a/duneggd/Component/STTModule.py
+++ b/duneggd/Component/STTModule.py
@@ -30,12 +30,12 @@ class STTModuleBuilder(gegede.builder.Builder):
         # main volume
         main_lv, main_hDim = ltools.main_lv( self, geom, "Box")
         print( "STTModule::construct()")
-        print( "  main_lv = "+ main_lv.name)
+        print(( "  main_lv = "+ main_lv.name))
         self.add_volume( main_lv )
 
         # Straw Plane 1
         plane1_builder=self.get_builder("STTPlane1")
-        print( "plane1_builder="+str(plane1_builder))
+        print(( "plane1_builder="+str(plane1_builder)))
         plane1_lv=plane1_builder.get_volume()
         plane1_pos=geom.structure.Position(self.name+'_Plane1_pos',
                                            self.centerPlane1[0],self.centerPlane1[1],self.centerPlane1[2])
@@ -47,7 +47,7 @@ class STTModuleBuilder(gegede.builder.Builder):
 
         # Straw Plane 2
         plane2_builder=self.get_builder("STTPlane2")
-        print( "plane2_builder="+str(plane2_builder))
+        print(( "plane2_builder="+str(plane2_builder)))
         plane2_lv=plane2_builder.get_volume()
         plane2_pos=geom.structure.Position(self.name+'_Plane2_pos',
                                            self.centerPlane2[0],self.centerPlane2[1],self.centerPlane2[2])

--- a/duneggd/Component/STTPlane.py
+++ b/duneggd/Component/STTPlane.py
@@ -35,7 +35,7 @@ class STTPlaneBuilder(gegede.builder.Builder):
 
             # initial position, particular case
             pos = [-main_hDim[0]+sb_dim[0]*0.5, Q('0m'), Q('0m')]
-            print( "STTPlane sb_dim[]= "+str(sb_dim))
+            print(( "STTPlane sb_dim[]= "+str(sb_dim)))
             for elem in range(self.NElements):
                 pos = [ sb_dim[0]*0.5+pos[0], pos[1]-math.pow(-1,elem+1)*sb_dim[0]*math.sqrt(3)*0.5, pos[2] ]
                 sb_pos = geom.structure.Position(self.name+sb_lv.name+str(elem)+'_pos',

--- a/duneggd/Component/SingleArrangePlane.py
+++ b/duneggd/Component/SingleArrangePlane.py
@@ -32,4 +32,4 @@ class SingleArrangePlaneBuilder(gegede.builder.Builder):
                 TranspV = self.TranspV
             ltools.placeBuilders( self, geom, main_lv, TranspV )
         else:
-            print( "**Warning, no Elements to place inside "+ self.name)
+            print(( "**Warning, no Elements to place inside "+ self.name))

--- a/duneggd/Det/IronDipole.py
+++ b/duneggd/Det/IronDipole.py
@@ -102,7 +102,7 @@ class IronDipoleBuilder(gegede.builder.Builder):
         # dimensions of the outside of the magnet yoke
         # includes gaps between yoke segments
         magBoxOutDim   = list(self.MagnetBldr.MagnetSystemOuterDimension)
-        print("IronDipoleBuilder::construct():  magBoxOutDim = ",magBoxOutDim)
+        print(("IronDipoleBuilder::construct():  magBoxOutDim = ",magBoxOutDim))
 
 #	ecalBarPos  = list(self.ecalBaPos)
 
@@ -129,7 +129,7 @@ class IronDipoleBuilder(gegede.builder.Builder):
         innerDet_shape = geom.shapes.Box('innerDet', dx=0.5*innerDet_dim[0],
                                          dy=0.5*innerDet_dim[1],dz=0.5*innerDet_dim[2])
         innerDet_lv= geom.structure.Volume('innerDet_volume',material='Air',shape=innerDet_shape)
-        print("Setting IronDipole inner detector field to ",self.innerDetBField)
+        print(("Setting IronDipole inner detector field to ",self.innerDetBField))
         innerDet_lv.params.append(("BField",self.innerDetBField))
         ######### ecal and trackers inside inner detector ######
         self.build_ecal(innerDet_lv,geom)
@@ -149,7 +149,7 @@ class IronDipoleBuilder(gegede.builder.Builder):
         innerDet_pla=geom.structure.Placement("innerDet_pla",
                                               volume=innerDet_lv,
                                               pos=innerDet_pos)
-        print("appending ",innerDet_pla.name, " to ", main_lv.name)
+        print(("appending ",innerDet_pla.name, " to ", main_lv.name))
 
         main_lv.placements.append(innerDet_pla.name)
 
@@ -258,7 +258,7 @@ class IronDipoleBuilder(gegede.builder.Builder):
     def build_stt(self,det_lv,geom):
         print("IronDipoleBuilder::build_stt(...) called")
         stt_lv = self.STTBldr.get_volume('volSTT')
-        print("IronDipoleBuilder::build_stt(...) STT placed at ", self.STTPos)
+        print(("IronDipoleBuilder::build_stt(...) STT placed at ", self.STTPos))
         stt_pos = geom.structure.Position('STT_pos', 
                                           self.STTPos[0], self.STTPos[1], self.STTPos[2])
         stt_pla = geom.structure.Placement('STT_pla',
@@ -272,7 +272,7 @@ class IronDipoleBuilder(gegede.builder.Builder):
         
         print("IronDipoleBuilder::build_a3dst(...) called")
         a3dst_lv = self.A3DSTBldr.get_volume('volA3DST')
-        print("IronDipoleBuilder::build_a3dst(...) A3DST placed at ", self.A3DSTPos)
+        print(("IronDipoleBuilder::build_a3dst(...) A3DST placed at ", self.A3DSTPos))
         a3dst_pos = geom.structure.Position('a3DST_pos', 
                                             self.A3DSTPos[0], self.A3DSTPos[1], self.A3DSTPos[2])
         a3dst_pla = geom.structure.Placement('a3DST_pla',
@@ -285,7 +285,7 @@ class IronDipoleBuilder(gegede.builder.Builder):
     def build_gartpc(self,det_lv,geom):
         print("IronDipoleBuilder::build_gartpc(...) called")
         gartpc_lv = self.GArTPCBldr.get_volume('volGArTPC')
-        print("IronDipoleBuilder::build_gartpc(...) GArTPC placed at ", self.GArTPCPos)
+        print(("IronDipoleBuilder::build_gartpc(...) GArTPC placed at ", self.GArTPCPos))
         gartpc_pos = geom.structure.Position('GArTPC_pos', 
                                              self.GArTPCPos[0], self.GArTPCPos[1], self.GArTPCPos[2])
         gartpc_rot = geom.structure.Rotation('GArTPC_rot', 

--- a/duneggd/Det/Minimal_3DST_for_KLOE.py
+++ b/duneggd/Det/Minimal_3DST_for_KLOE.py
@@ -186,9 +186,9 @@ class Minimal_3DST_Builder(gegede.builder.Builder):
     def getTPC(self, full3dst_lv, tpcPos, geom):
 
         print('location of TPC')
-        print(self.tpcPos[0])
-        print(self.tpcPos[1])
-        print(self.tpcPos[2])
+        print((self.tpcPos[0]))
+        print((self.tpcPos[1]))
+        print((self.tpcPos[2]))
 
         tpcBox = geom.shapes.Box('tpc', dx=0.5*self.tpcDim[0], dy=0.5*self.tpcDim[1], dz=0.5*self.tpcDim[2])
 
@@ -219,9 +219,9 @@ class Minimal_3DST_Builder(gegede.builder.Builder):
     def getEcal(self, full3dst_lv, ecalPos, geom):
 
         print('location of ECAL')
-        print(ecalPos[0])
-        print(ecalPos[1])
-        print(ecalPos[2])
+        print((ecalPos[0]))
+        print((ecalPos[1]))
+        print((ecalPos[2]))
 
         ecalMod = geom.shapes.Box( 'ecalBox',
                                   dx = 0.5*self.ecalModDim[0],
@@ -369,9 +369,9 @@ class Minimal_3DST_Builder(gegede.builder.Builder):
     def getMagnet(self, full3dst_lv, magPos, geom):
 
         print('magnet location')
-        print(magPos[0])
-        print(magPos[1])
-        print(magPos[2])
+        print((magPos[0]))
+        print((magPos[1]))
+        print((magPos[2]))
 
         magOut = geom.shapes.Box( 'MagOut', dx = 0.5*self.magOutDim[0], dy = 0.5*self.magOutDim[1], dz = 0.5*self.magOutDim[2])
         magIn = geom.shapes.Box ('MagInner', dx = 0.5*self.magInDim[0], dy = 0.5*self.magInDim[1], dz = 0.5*self.magInDim[2])
@@ -391,9 +391,9 @@ class Minimal_3DST_Builder(gegede.builder.Builder):
     def getRPC(self, full3dst_lv, rpcPos, geom):
 
         print('rpc location')
-        print(rpcPos[0])
-        print(rpcPos[1])
-        print(rpcPos[2])
+        print((rpcPos[0]))
+        print((rpcPos[1]))
+        print((rpcPos[2]))
 
         rpcModDim = self.rpcModDim
         rpcModBox = geom.shapes.Box('rpcModBox', dx=0.5*self.rpcModDim[0], dy=0.5*self.rpcModDim[1], dz=0.5*rpcModDim[2])
@@ -441,9 +441,9 @@ class Minimal_3DST_Builder(gegede.builder.Builder):
     def getCylinder(self, full3dst_lv, cylinderPos, geom):
 
         print('Cylinder location')
-        print(self.cylinderPos[0])
-        print(self.cylinderPos[1])
-        print(self.cylinderPos[2])
+        print((self.cylinderPos[0]))
+        print((self.cylinderPos[1]))
+        print((self.cylinderPos[2]))
 
         cylinderShape = geom.shapes.Tubs('cylinderShape', rmin=0.5*self.cylinderDim[0], rmax=self.cylinderDim[1], dz=0.5*self.cylinderDim[2], sphi=self.cylinderDim[3], dphi=self.cylinderDim[4])
 

--- a/duneggd/Det/Secondary.py
+++ b/duneggd/Det/Secondary.py
@@ -80,10 +80,10 @@ class SecondaryBuilder(gegede.builder.Builder):
         # first check to see if ecal barrel fits in magnet, otherwise nudge it to fit
         # need to do this before using and magnet dimensions for positioning
         if( self.magInDim[1] < ecalBarDim[1] ):
-             print( "DetectorBuilder: Barrel ECAL ("+str(ecalBarDim[1])+" high) does not fit inside magnet ("+str(self.magInDim[1])+")")
+             print(( "DetectorBuilder: Barrel ECAL ("+str(ecalBarDim[1])+" high) does not fit inside magnet ("+str(self.magInDim[1])+")"))
              self.magInDim[1]  = ecalBarDim[1]
              self.magOutDim[1] = self.magInDim[1] + 2*self.magThickness
-             print( "       ... nudging magnet inner and outer height dimensions to "+str(self.magInDim[1])+" and "+str(self.magOutDim[1]))
+             print(( "       ... nudging magnet inner and outer height dimensions to "+str(self.magInDim[1])+" and "+str(self.magOutDim[1])))
              print( "       ... this affects PRC placements, which fit tightly around magnet")
 
         # vol is a bounding box ~ not corresponding to physical volume.
@@ -150,33 +150,33 @@ class SecondaryBuilder(gegede.builder.Builder):
         #  where they should -- barrel is a "tube" in z and magnet a "tube" in x
         if( muidBarInDim[2] != muidBarOutDim[2] ):
             print( "DetectorBuilder: MuID barrel not same length in z on inside and outside")
-            print( "     inner barrel is "+str(muidBarInDim[2])+" and outer barrel is "+str(muidBarOutDim[2])+" in z")
+            print(( "     inner barrel is "+str(muidBarInDim[2])+" and outer barrel is "+str(muidBarOutDim[2])+" in z"))
         if( self.magInDim[0] != self.magOutDim[0] ):
             print( "DetectorBuilder: Magnet not same length in x on inside and outside")
-            print( "     inner magnet is "+str(self.magInDim[0])+" and outer magnet is "+str(self.magOutDim[0])+" in x")
+            print(( "     inner magnet is "+str(self.magInDim[0])+" and outer magnet is "+str(self.magOutDim[0])+" in x"))
 
         # The MuID barrel should tightly hug the magnet,
         #   and be the same dimension in z
         if( muidBarInDim[0] != self.magOutDim[0] ):
             print( "DetectorBuilder: MuID barrel not touching magnet in x")
-            print( "     inner barrel is "+str(muidBarInDim[0])+" and magnet is "+str(self.magOutDim[0])+" in x")
+            print(( "     inner barrel is "+str(muidBarInDim[0])+" and magnet is "+str(self.magOutDim[0])+" in x"))
         if( muidBarInDim[1] != self.magOutDim[1] ):
             print( "DetectorBuilder: MuID barrel not touching magnet in y")
-            print( "     inner barrel is "+str(muidBarInDim[1])+" and outer magnet is "+str(self.magOutDim[1])+" in y")
+            print(( "     inner barrel is "+str(muidBarInDim[1])+" and outer magnet is "+str(self.magOutDim[1])+" in y"))
         if( muidBarInDim[2] != self.magOutDim[2] ):
             print( "DetectorBuilder: MuID barrel not same length in z as magnet")
-            print( "     barrel is "+str(muidBarInDim[2])+" and outer magnet is "+str(self.magOutDim[2])+" in z")
+            print(( "     barrel is "+str(muidBarInDim[2])+" and outer magnet is "+str(self.magOutDim[2])+" in z"))
 
         # Check that the ECAL, positioned tightly around the STT, fits
         #   inside the inner dimensions of the magnet.
         if( (ecalUpPos[2] - 0.5*ecalUpDim[2]) < (magPos[2] - 0.5*self.magInDim[2]) ):
-            print( "DetectorBuilder: Upstream ECAL upstream z face ("+str(ecalUpPos[2] - 0.5*ecalUpDim[2])+") overlaps magnet ("+str(magPos[2] - 0.5*self.magInDim[2])+")")
-            print( "      ... downstream ECAL downstream face is "+str(magPos[2] + 0.5*self.magInDim[2] - (ecalDownPos[2] + 0.5*ecalDownDim[2]))+" away from magnet")
+            print(( "DetectorBuilder: Upstream ECAL upstream z face ("+str(ecalUpPos[2] - 0.5*ecalUpDim[2])+") overlaps magnet ("+str(magPos[2] - 0.5*self.magInDim[2])+")"))
+            print(( "      ... downstream ECAL downstream face is "+str(magPos[2] + 0.5*self.magInDim[2] - (ecalDownPos[2] + 0.5*ecalDownDim[2]))+" away from magnet"))
         if( (ecalDownPos[2] + 0.5*ecalDownDim[2]) > (magPos[2] + 0.5*self.magInDim[2]) ):
-            print( "DetectorBuilder: Downstream ECAL downstream z face ("+str(ecalDownPos[2] + 0.5*ecalDownDim[2])+") overlaps magnet ("+str(magPos[2] + 0.5*self.magInDim[2])+")")
-            print( "      ... upstream ECAL upstream face is "+str(ecalUpPos[2] - 0.5*ecalUpDim[2] - (magPos[2] - 0.5*self.magInDim[2]))+" away from magnet")
+            print(( "DetectorBuilder: Downstream ECAL downstream z face ("+str(ecalDownPos[2] + 0.5*ecalDownDim[2])+") overlaps magnet ("+str(magPos[2] + 0.5*self.magInDim[2])+")"))
+            print(( "      ... upstream ECAL upstream face is "+str(ecalUpPos[2] - 0.5*ecalUpDim[2] - (magPos[2] - 0.5*self.magInDim[2]))+" away from magnet"))
         if( self.magInDim[2] < ecalUpDim[2] + sttDim[2] + ecalDownDim[2] ):
-            print( "DetectorBuilder: STT+ECAL ends ("+str(ecalUpDim[2] + sttDim[2] + ecalDownDim[2])+") do not fit inside magnet ("+str(self.magInDim[2])+")")
+            print(( "DetectorBuilder: STT+ECAL ends ("+str(ecalUpDim[2] + sttDim[2] + ecalDownDim[2])+") do not fit inside magnet ("+str(self.magInDim[2])+")"))
  
         if(       muidDownDim[1] > muidBarDim[1] 
                or muidDownDim[2] > muidBarDim[2]

--- a/duneggd/Det/test_3DST.py
+++ b/duneggd/Det/test_3DST.py
@@ -99,9 +99,9 @@ class test_3DSTBuilder(gegede.builder.Builder):
     def getRPC(self, full3dst_lv, geom):
 
         print('RPC location')
-        print(self.rpcPos[0]) 
-        print(self.rpcPos[1]) 
-        print(self.rpcPos[2])
+        print((self.rpcPos[0])) 
+        print((self.rpcPos[1])) 
+        print((self.rpcPos[2]))
 
         rpcModBox = geom.shapes.Box('rpcModBox', #Q('1m'), Q('1m'),Q('1m'))
                                     dx=0.5*self.rpcModDim[0], 
@@ -190,9 +190,9 @@ class test_3DSTBuilder(gegede.builder.Builder):
     def getMagnet(self, full3dst_lv, magPos, geom):
 
         print('magnet location')
-        print(magPos[0])
-        print(magPos[1])
-        print(magPos[2])
+        print((magPos[0]))
+        print((magPos[1]))
+        print((magPos[2]))
 
         magOut = geom.shapes.Box( 'MagOut',                 dx=0.5*self.magOutDim[0],
                                   dy=0.5*self.magOutDim[1], dz=0.5*self.magOutDim[2])
@@ -230,9 +230,9 @@ class test_3DSTBuilder(gegede.builder.Builder):
     def getTPC(self, full3dst_lv, tpcPos, geom):
 
         print('location of TPC')
-        print(self.tpcPos[0])
-        print(self.tpcPos[1])
-        print(self.tpcPos[2])
+        print((self.tpcPos[0]))
+        print((self.tpcPos[1]))
+        print((self.tpcPos[2]))
 
         tpcBox = geom.shapes.Box( 'tpc',                 dx=0.5*self.tpcDim[0],
                               dy=0.5*self.tpcDim[1], dz=0.5*self.tpcDim[2])
@@ -280,9 +280,9 @@ class test_3DSTBuilder(gegede.builder.Builder):
     def getA3dst(self, full3dst_lv, a3dstPos, geom):
 
         print('location of 3DST')
-        print(a3dstPos[0])
-        print(a3dstPos[1])
-        print(a3dstPos[2])
+        print((a3dstPos[0]))
+        print((a3dstPos[1]))
+        print((a3dstPos[2]))
 
         nCubeX = self.nCubeX
         nCubeY = self.nCubeY
@@ -331,9 +331,9 @@ class test_3DSTBuilder(gegede.builder.Builder):
     def getEcal(self, full3dst_lv, ecalPos, geom):
 
         print('location of ECAL')
-        print(ecalPos[0])
-        print(ecalPos[1])
-        print(ecalPos[2])
+        print((ecalPos[0]))
+        print((ecalPos[1]))
+        print((ecalPos[2]))
 
         ecalMod = geom.shapes.Box( 'ecalBox',
                                   dx = 0.5*self.ecalModDim[0],

--- a/duneggd/Det/threeDST_inKLOE.py
+++ b/duneggd/Det/threeDST_inKLOE.py
@@ -183,9 +183,9 @@ class threeDST_inKLOE_Builder(gegede.builder.Builder):
     def getTPC(self, full3dst_lv, tpcPos, geom):
 
         print('location of TPC')
-        print(self.tpcPos[0])
-        print(self.tpcPos[1])
-        print(self.tpcPos[2])
+        print((self.tpcPos[0]))
+        print((self.tpcPos[1]))
+        print((self.tpcPos[2]))
 
         tpcBox = geom.shapes.Box('tpc', dx=0.5*self.tpcDim[0], dy=0.5*self.tpcDim[1], dz=0.5*self.tpcDim[2])
 
@@ -216,9 +216,9 @@ class threeDST_inKLOE_Builder(gegede.builder.Builder):
     def getEcal(self, full3dst_lv, ecalPos, geom):
 
         print('location of ECAL')
-        print(ecalPos[0])
-        print(ecalPos[1])
-        print(ecalPos[2])
+        print((ecalPos[0]))
+        print((ecalPos[1]))
+        print((ecalPos[2]))
 
         ecalMod = geom.shapes.Box( 'ecalBox',
                                   dx = 0.5*self.ecalModDim[0],
@@ -366,9 +366,9 @@ class threeDST_inKLOE_Builder(gegede.builder.Builder):
     def getMagnet(self, full3dst_lv, magPos, geom):
 
         print('magnet location')
-        print(magPos[0])
-        print(magPos[1])
-        print(magPos[2])
+        print((magPos[0]))
+        print((magPos[1]))
+        print((magPos[2]))
 
         magOut = geom.shapes.Box( 'MagOut', dx = 0.5*self.magOutDim[0], dy = 0.5*self.magOutDim[1], dz = 0.5*self.magOutDim[2])
         magIn = geom.shapes.Box ('MagInner', dx = 0.5*self.magInDim[0], dy = 0.5*self.magInDim[1], dz = 0.5*self.magInDim[2])
@@ -388,9 +388,9 @@ class threeDST_inKLOE_Builder(gegede.builder.Builder):
     def getRPC(self, full3dst_lv, rpcPos, geom):
 
         print('rpc location')
-        print(rpcPos[0])
-        print(rpcPos[1])
-        print(rpcPos[2])
+        print((rpcPos[0]))
+        print((rpcPos[1]))
+        print((rpcPos[2]))
        
         rpcModDim = self.rpcModDim
         rpcModBox = geom.shapes.Box('rpcModBox', dx=0.5*self.rpcModDim[0], dy=0.5*self.rpcModDim[1], dz=0.5*rpcModDim[2])
@@ -438,9 +438,9 @@ class threeDST_inKLOE_Builder(gegede.builder.Builder):
     def getCylinder(self, full3dst_lv, cylinderPos, geom):
 
         print('Cylinder location')
-        print(self.cylinderPos[0])
-        print(self.cylinderPos[1])
-        print(self.cylinderPos[2])
+        print((self.cylinderPos[0]))
+        print((self.cylinderPos[1]))
+        print((self.cylinderPos[2]))
 
         cylinderShape = geom.shapes.Tubs('cylinderShape', rmin=0.5*self.cylinderDim[0], rmax=self.cylinderDim[1], dz=0.5*self.cylinderDim[2], sphi=self.cylinderDim[3], dphi=self.cylinderDim[4])
 

--- a/duneggd/SubDetector/ComplexSubDetector.py
+++ b/duneggd/SubDetector/ComplexSubDetector.py
@@ -36,4 +36,4 @@ class ComplexSubDetectorBuilder(gegede.builder.Builder):
                 TranspV = self.TranspV
             ltools.placeComplexBuilders( self, geom, main_lv, TranspV )
         else:
-            print( "**Warning, no Elements to place inside "+ self.name)
+            print(( "**Warning, no Elements to place inside "+ self.name))

--- a/duneggd/SubDetector/ECALBarrel.py
+++ b/duneggd/SubDetector/ECALBarrel.py
@@ -28,14 +28,14 @@ class ECALBarrelBuilder(gegede.builder.Builder):
         ecalModDim = list(self.ECALBarModBldr.ecalModDim)
         ecalModThick = ecalModDim[2]
         ecalModWide = ecalModDim[1]
-        print("ecalModDim = ",ecalModDim)
-        print("ecalModThick = ",ecalModThick)
-        print("ecalModWide = ",ecalModWide)
+        print(("ecalModDim = ",ecalModDim))
+        print(("ecalModThick = ",ecalModThick))
+        print(("ecalModWide = ",ecalModWide))
         # Define inner barrel dimensions with stt dim and thickness
         sttDim = self.sttDimension
-        print("0.5*sttDim[1] = ",0.5*sttDim[1])
-        print("0.5*ecalModThick = ",0.5*ecalModThick)
-        print("self.sTubeEndsToLead = ", self.sTubeEndsToLead)
+        print(("0.5*sttDim[1] = ",0.5*sttDim[1]))
+        print(("0.5*ecalModThick = ",0.5*ecalModThick))
+        print(("self.sTubeEndsToLead = ", self.sTubeEndsToLead))
         
         # MAK: this code is buggy. 
         self.ecalInDim  = [ sttDim[0] + 2*self.sTubeEndsToLead,

--- a/duneggd/SubDetector/ECALMod.py
+++ b/duneggd/SubDetector/ECALMod.py
@@ -54,7 +54,7 @@ class ECALModBuilder(gegede.builder.Builder):
         # Calculate ECAL dimensions 
         self.ecalModDim    = list(SBPlaneDim) # get the right x and y dimension
         self.ecalModDim[2] = self.nSBPlanes*(self.leadThickness + SBPlaneDim[2])
-        print( 'ECALModBuilder: set ECAL z dimension to '+str(self.ecalModDim[2])+' (configured as '+str(self.ecalThickness)+')')
+        print(( 'ECALModBuilder: set ECAL z dimension to '+str(self.ecalModDim[2])+' (configured as '+str(self.ecalThickness)+')'))
       
         # Make main shape/volume for this builder
         ecalModBox = geom.shapes.Box( self.name,
@@ -71,7 +71,7 @@ class ECALModBuilder(gegede.builder.Builder):
         n2 = 0
         for i in range(self.nSBPlanes):
             zpos = -0.5*self.ecalModDim[2]+ (i+0.5)*SBPlaneDim[2]+(i+1)*self.leadThickness +self.zXtra
-            print("placing ecal SBPlane %i at zpos=%f cm"%(i,zpos/Q("1cm")))
+            print(("placing ecal SBPlane %i at zpos=%f cm"%(i,zpos/Q("1cm"))))
 	    rotPlane = 'identity'
 	    #if(self.altPlaneOrient): rotPlane = 'r90aboutZ'
 
@@ -93,6 +93,6 @@ class ECALModBuilder(gegede.builder.Builder):
                 n2=n2+1
          
             #ecalMod_lv.params.append(("SensDet",self.name))       
-            print( 'ECALModBuilder: '+str(i+1) +' SBPlanes in '+str(self.name))
+            print(( 'ECALModBuilder: '+str(i+1) +' SBPlanes in '+str(self.name)))
         #print( str(n1)+ ' SBPlanes have scint. bars oriented along X direction and '+ str(n2)+ ' SBPlanes have scint. bars oriented along Y direction for '+str(self.name) )
         return

--- a/duneggd/SubDetector/GArTPC.py
+++ b/duneggd/SubDetector/GArTPC.py
@@ -202,7 +202,7 @@ class GArTPCBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Tubs')
         print('GasTPCBuilder::construct()')
-        print('main_lv = '+main_lv.name)
+        print(('main_lv = '+main_lv.name))
         self.add_volume(main_lv)
 
         # Construct the chamber

--- a/duneggd/SubDetector/Grain.py
+++ b/duneggd/SubDetector/Grain.py
@@ -88,7 +88,7 @@ class GrainBuilder(gegede.builder.Builder):
             main_lv = self.construct_GRAIN_option2(geom)
 
         #main_lv = self.construct_GRAIN(geom)
-        print( "  main_lv = "+ main_lv.name)
+        print(( "  main_lv = "+ main_lv.name))
         self.add_volume( main_lv )
 
 #############################################################         GRAIN   1      ###################################################################

--- a/duneggd/SubDetector/KLOE3DST_STT.py
+++ b/duneggd/SubDetector/KLOE3DST_STT.py
@@ -20,7 +20,7 @@ class KLOE3DST_STT_builder(gegede.builder.Builder):
                    foilChunkThickness=None, coatThickness=None, mylarThickness=None,
                    **kwds):        
         self.start_time=time.time()
-        print("start_time:",self.start_time)
+        print(("start_time:",self.start_time))
         self.halfDimension, self.Material = ( halfDimension, Material )
         self.useRegMod=useRegMod
         self.Height3DST=Box3DSTDim[1]
@@ -37,7 +37,7 @@ class KLOE3DST_STT_builder(gegede.builder.Builder):
         if useRegMod!=True:
             print("NOTE-------------------- use nos mod instead of reg")
             self.nRear2Mod=nRear2Mod_nos
-        print("self.nRear2Mod:",self.nRear2Mod)
+        print(("self.nRear2Mod:",self.nRear2Mod))
         self.nRear3Mod=nRear3Mod
         self.offset3DSTcenter=offset3DSTcenter
         self.strawRadius=strawRadius
@@ -86,25 +86,25 @@ class KLOE3DST_STT_builder(gegede.builder.Builder):
         test_nRear2 = kloeTrkRegRadius - self.Depth3DST/2 + self.offset3DSTcenter - (self.pureSTModThickness+self.pureSTModGap)*self.nRear1Mod - self.noSlabModThickness*self.nRear3Mod
         test_nRear2A=test_nRear2/self.regModThickness
         test_nRear2B=test_nRear2/self.noSlabModThickness
-        print("test_nfront:",test_nfront)
-        print("test_nMid:",test_nMid)
-        print("test_nRear2A:",test_nRear2A)
-        print("test_nRear2B:",test_nRear2B)
+        print(("test_nfront:",test_nfront))
+        print(("test_nMid:",test_nMid))
+        print(("test_nRear2A:",test_nRear2A))
+        print(("test_nRear2B:",test_nRear2B))
         
         self.frontGap=kloeTrkRegRadius- (self.pureSTModThickness+self.pureSTModGap)*self.nFrontMod - self.Depth3DST/2 - self.offset3DSTcenter
-        print("front gap:",self.frontGap)
+        print(("front gap:",self.frontGap))
 
         rearModsWidth=(self.pureSTModThickness+self.pureSTModGap)*self.nRear1Mod + self.regModThickness*self.nRear2Mod + self.noSlabModThickness*self.nRear3Mod
         self.rearGap= kloeTrkRegRadius - self.Depth3DST/2 + self.offset3DSTcenter - rearModsWidth
-        print("rearModsWidth:",rearModsWidth)
-        print("self.rearGap:",self.rearGap)
+        print(("rearModsWidth:",rearModsWidth))
+        print(("self.rearGap:",self.rearGap))
     
-        print("totfoilThickness:",totfoilThickness)
-        print("self.slabThickness:",self.slabThickness)
-        print("planeXXThickness:",planeXXThickness)
-        print("regModThickness:",regModThickness)
-        print("cModThickness:",cModThickness)
-        print("noSlabModThickness:",noSlabModThickness)
+        print(("totfoilThickness:",totfoilThickness))
+        print(("self.slabThickness:",self.slabThickness))
+        print(("planeXXThickness:",planeXXThickness))
+        print(("regModThickness:",regModThickness))
+        print(("cModThickness:",cModThickness))
+        print(("noSlabModThickness:",noSlabModThickness))
 
         main_lv, main_hDim = ltools.main_lv( self, geom, "Tubs")
         self.add_volume( main_lv )

--- a/duneggd/SubDetector/KLOESTT.py
+++ b/duneggd/SubDetector/KLOESTT.py
@@ -22,7 +22,7 @@ class KLOESTTBuilder(gegede.builder.Builder):
         # main volume
         main_lv, main_hDim = ltools.main_lv( self, geom, "Box")
         print( "KLOESTT::construct()")
-        print( "  main_lv = "+ main_lv.name)
+        print(( "  main_lv = "+ main_lv.name))
         self.add_volume( main_lv )
 
         rot=[Q("0deg"),Q("0deg"),Q("0deg")]
@@ -37,7 +37,7 @@ class KLOESTTBuilder(gegede.builder.Builder):
         for imod in range(self.nModules):
             loc=[Q("0cm"),Q("0cm"),startz+(self.modWidth+self.gap)*(imod+0.5)]
             basename=self.name+'_'+mod_lv.name+'_'+str(imod)
-            print( "Placing STTModule " + basename+" at "+str(loc))
+            print(( "Placing STTModule " + basename+" at "+str(loc)))
             mod_pos=geom.structure.Position(basename+'_pos',loc[0],loc[1],loc[2])
             mod_rot=geom.structure.Rotation(basename+'_rot',rot[0],rot[1],rot[2])
             mod_pla=geom.structure.Placement(basename+'_pla',volume=mod_lv,pos=mod_pos,rot=mod_rot)

--- a/duneggd/SubDetector/Magnet.py
+++ b/duneggd/SubDetector/Magnet.py
@@ -43,8 +43,8 @@ class MagnetBuilder(gegede.builder.Builder):
 
         ##### make the geometry for a coil segment ##########################
         # the coil is segmented along X
-        print("MagnetBuilder  coil segment outer dimensions = ",self.magOutDim)
-        print("MagnetBuilder  coil segment inner dimensions = ",self.magInDim)
+        print(("MagnetBuilder  coil segment outer dimensions = ",self.magOutDim))
+        print(("MagnetBuilder  coil segment inner dimensions = ",self.magInDim))
         magOut = geom.shapes.Box( 'MagOut',                 dx=0.5*self.magOutDim[0], 
                                   dy=0.5*self.magOutDim[1], dz=0.5*self.magOutDim[2]) 
         magIn = geom.shapes.Box(  'MagInner',               dx=0.5*self.magInDim[0]+epsilon, 
@@ -56,8 +56,8 @@ class MagnetBuilder(gegede.builder.Builder):
 
         ##### make the geometry for a yoke segment ###########################
         # the yoke is segmented along z
-        print("MagnetBuilder  yoke segment outer dimensions = ",self.magOutDimB)
-        print("MagnetBuilder  yoke segment inner dimensions = ",self.magInDimB)
+        print(("MagnetBuilder  yoke segment outer dimensions = ",self.magOutDimB))
+        print(("MagnetBuilder  yoke segment inner dimensions = ",self.magInDimB))
         magOutB = geom.shapes.Box( 'YokeOut',                 dx=0.5*self.magOutDimB[0],
                                   dy=0.5*self.magOutDimB[1], dz=0.5*self.magOutDimB[2])
         magInB = geom.shapes.Box(  'YokeInner',               dx=0.5*self.magInDimB[0],
@@ -69,8 +69,8 @@ class MagnetBuilder(gegede.builder.Builder):
         self.MagnetOutt = [self.magOutDimB[0], self.magOutDimB[1], (self.magOutDimB[2]+self.magBGap)*self.nMagB]
 	self.MagnetInn = [(self.magInDim[0]+self.magGap)*self.nMag, self.magInDim[1], self.magInDim[2]]
 
-        print("MagnetBuilder  full yoke outer dimensions = ",self.MagnetOutt)
-        print("MagnetBuilder  full coil inner dimesions = ",self.MagnetInn)
+        print(("MagnetBuilder  full yoke outer dimensions = ",self.MagnetOutt))
+        print(("MagnetBuilder  full coil inner dimesions = ",self.MagnetInn))
         
         ## define the inner dimensions of the magnet system
         magnetIn = geom.shapes.Box('MagnetInner',dx=0.5*self.MagnetInn[0], 

--- a/duneggd/SubDetector/MuIDBarrel.py
+++ b/duneggd/SubDetector/MuIDBarrel.py
@@ -59,14 +59,14 @@ class MuIDBarrelBuilder(gegede.builder.Builder):
         # Steel Sheets: just leave the default material of volMuID* steel 
         #   and leave spaces instead of placing explicit volumes
 	
-        print( 'Abs pos for '+ str(self.name) +' along Z: '+ str(self.muidAbsPos[2]))
-        print( math.cos(math.radians(60)))
+        print(( 'Abs pos for '+ str(self.name) +' along Z: '+ str(self.muidAbsPos[2])))
+        print(( math.cos(math.radians(60))))
         EachAngle = int(360/self.nMuTracker)
 
  	#EachAngle = 0
 	for ii in range(self.nMuTracker):
 		Zrot         = Q('0deg')+EachAngle*ii*Q('1deg')
-		print( 'rotating angle of '+str(ii)+' muon tracker: '+str(Zrot))
+		print(( 'rotating angle of '+str(ii)+' muon tracker: '+str(Zrot)))
 		#rAboutXZ     = geom.structure.Rotation( 'rAboutXZ'+str(ii), '0deg',  '0deg', -Zrot+Q('90deg')  )	
 		rAboutXZ     = geom.structure.Rotation( 'rAboutXZ'+str(ii),  Zrot-Q('0deg') , '0deg', '0deg'  )
 
@@ -77,7 +77,7 @@ class MuIDBarrelBuilder(gegede.builder.Builder):
             xpos = self.muidDim[0] + self.muidAbsPos[0]
             ypos = self.muidDim[1]*math.sin(Zrot) + self.muidAbsPos[1]
             zpos = self.muidDim[1]*math.cos(Zrot) + self.muidAbsPos[2]
-            print( 'position of tracker: '+str(xpos)+' '+str(ypos)+' '+str(zpos))
+            print(( 'position of tracker: '+str(xpos)+' '+str(ypos)+' '+str(zpos)))
 
             for j in range(self.nTraysPerPlane):
                 #xpos = -0.5*self.muidDim[0]+self.muidAbsPos[0]

--- a/duneggd/SubDetector/MuIDEnd.py
+++ b/duneggd/SubDetector/MuIDEnd.py
@@ -57,7 +57,7 @@ class MuIDEndBuilder(gegede.builder.Builder):
         # Steel Sheets: just leave the default material of volMuID* steel 
         #   and leave spaces instead of placing explicit volumes
 	
-        print( 'Abs pos for '+ str(self.name) +' along Z: '+ str(self.muidAbsPos[2]))
+        print(( 'Abs pos for '+ str(self.name) +' along Z: '+ str(self.muidAbsPos[2])))
         
         for i in range(self.nPlanes):
             zpos = -0.5*self.muidDim[2]+(i+0.5)*rpcTrayDim[2]+i*self.steelPlateDim[2]+self.muidAbsPos[2]

--- a/duneggd/SubDetector/NDGArLite.py
+++ b/duneggd/SubDetector/NDGArLite.py
@@ -48,8 +48,8 @@ class NDGArLite(gegede.builder.Builder):
         dy_main = r+self.space  # dimension in height
         dz_main = dz+self.space  # dimension perp to the beam
 
-        print("Dimension of the MPD in along the beam ", dx_main*2,
-              " dimension in height ", dy_main*2, " and dimension perp to the beam ", dz_main*2)
+        print(("Dimension of the MPD in along the beam ", dx_main*2,
+              " dimension in height ", dy_main*2, " and dimension perp to the beam ", dz_main*2))
 
         main_shape = geom.shapes.Box('MPD', dx=dx_main, dy=dy_main, dz=dz_main)
         main_lv = geom.structure.Volume(
@@ -150,7 +150,7 @@ class NDGArLite(gegede.builder.Builder):
         byoke_vol = yoke_builder.get_volume("volYokeBarrel")
         yoke_shape = geom.store.shapes.get(byoke_vol.shape)
         nsides = yoke_shape.numsides
-        print("Number of yoke sides", nsides)
+        print(("Number of yoke sides", nsides))
 
         rot_z = Q("90.0deg")-Q("180.0deg")/nsides
         if nsides == 16:

--- a/duneggd/SubDetector/NDHPgTPC.py
+++ b/duneggd/SubDetector/NDHPgTPC.py
@@ -54,7 +54,7 @@ class NDHPgTPC_Builder(gegede.builder.Builder):
         dy_main=r+self.space #dimension in height
         dz_main=dz+self.space #dimension perp to the beam
 
-        print("Dimension of the MPD in along the beam ", dx_main*2, " dimension in height ", dy_main*2, " and dimension perp to the beam ", dz_main*2)
+        print(("Dimension of the MPD in along the beam ", dx_main*2, " dimension in height ", dy_main*2, " and dimension perp to the beam ", dz_main*2))
 
         main_shape = geom.shapes.Box('MPD', dx=dx_main, dy=dy_main, dz=dz_main)
         main_lv = geom.structure.Volume('vol'+main_shape.name, material='Air', shape=main_shape)
@@ -227,7 +227,7 @@ class NDHPgTPC_Builder(gegede.builder.Builder):
         byoke_vol = yoke_builder.get_volume("volYokeBarrel")
         yoke_shape = geom.store.shapes.get(byoke_vol.shape)
         nsides = yoke_shape.numsides
-        print("Number of yoke sides", nsides)
+        print(("Number of yoke sides", nsides))
 
         rot_z = Q("90.0deg")-Q("180.0deg")/nsides
         if nsides == 16:

--- a/duneggd/SubDetector/NDHPgTPC_SPYv3.py
+++ b/duneggd/SubDetector/NDHPgTPC_SPYv3.py
@@ -51,7 +51,7 @@ class NDHPgTPC_SPYv3_Builder(gegede.builder.Builder):
         dy_main=r+self.space #dimension in height
         dz_main=dz+self.space #dimension perp to the beam
 
-        print("Dimension of the MPD in along the beam ", dx_main*2, " dimension in height ", dy_main*2, " and dimension perp to the beam ", dz_main*2)
+        print(("Dimension of the MPD in along the beam ", dx_main*2, " dimension in height ", dy_main*2, " and dimension perp to the beam ", dz_main*2))
 
         main_shape = geom.shapes.Box('MPD', dx=dx_main, dy=dy_main, dz=dz_main)
         main_lv = geom.structure.Volume('vol'+main_shape.name, material='Air', shape=main_shape)
@@ -195,7 +195,7 @@ class NDHPgTPC_SPYv3_Builder(gegede.builder.Builder):
         byoke_vol = yoke_builder.get_volume("volYokeBarrel")
         yoke_shape = geom.store.shapes.get(byoke_vol.shape)
         nsides = yoke_shape.numsides
-        print("Number of yoke sides", nsides)
+        print(("Number of yoke sides", nsides))
 
         rot_z = Q("90.0deg")-Q("180.0deg")/nsides
         if nsides == 16:

--- a/duneggd/SubDetector/SAND.py
+++ b/duneggd/SubDetector/SAND.py
@@ -72,7 +72,7 @@ class SANDBuilder(gegede.builder.Builder):
     def construct(self, geom):
         main_lv, main_hDim = ltools.main_lv( self, geom, "Box")
         print("KLOEBuilder::construct()")
-        print("main_lv = "+ main_lv.name)
+        print(("main_lv = "+ main_lv.name))
         self.add_volume( main_lv )
         self.build_yoke(main_lv, geom)
         self.build_solenoid(main_lv, geom)
@@ -102,7 +102,7 @@ class SANDBuilder(gegede.builder.Builder):
         pos = [Q('0m'),Q('0m'),Q('0m')]
 
         BField="(%f T, 0.0 T, 0.0 T)"%(self.CentralBField/Q("1.0T"))
-        print( "Setting internal Bfield to "+str(BField))
+        print(( "Setting internal Bfield to "+str(BField)))
         MagIntVol_volume.params.append(("BField",BField))
 
         MagIntVol_pos=geom.structure.Position("MagIntVol_pos", pos[0],pos[1], pos[2])
@@ -127,7 +127,7 @@ class SANDBuilder(gegede.builder.Builder):
         
         self.build_inner_volume(MagIntVol_volume, geom)
 
-        print("printing main_lv: " + str(main_lv))
+        print(("printing main_lv: " + str(main_lv)))
 
 
 #        TranspV = [0,0,1]
@@ -176,7 +176,7 @@ class SANDBuilder(gegede.builder.Builder):
 
 #        BField="(0.0 T, 0.0 T, %f T)"%(-BarrelBField/Q("1.0T"))
         BField="(%f T, 0.0 T, 0.0 T)"%(-BarrelBField/Q("1.0T"))
-        print("Setting KLOE Barrel Bfield to "+str(BField))
+        print(("Setting KLOE Barrel Bfield to "+str(BField)))
         barrel_lv.params.append(("BField",BField))
 
 
@@ -186,7 +186,7 @@ class SANDBuilder(gegede.builder.Builder):
         barrel_pla=geom.structure.Placement("KLOEYokeBarrel_pla",
                                             volume=barrel_lv,
                                             pos=barrel_pos)
-        print("appending "+barrel_pla.name)
+        print(("appending "+barrel_pla.name))
         main_lv.placements.append(barrel_pla.name)
 
         # build endcap
@@ -217,7 +217,7 @@ class SANDBuilder(gegede.builder.Builder):
                 ec_pla=geom.structure.Placement(name+"_pla",
                                                 volume=ec_lv,
                                                 pos=ec_pos)
-                print("appending "+ec_pla.name)
+                print(("appending "+ec_pla.name))
                 main_lv.placements.append(ec_pla.name)
 
 
@@ -265,7 +265,7 @@ class SANDBuilder(gegede.builder.Builder):
             ec_pla=geom.structure.Placement(name+"_pla",
                                             volume=ec_lv,
                                             pos=ec_pos)
-            print("appending "+ec_pla.name)
+            print(("appending "+ec_pla.name))
             main_lv.placements.append(ec_pla.name)
 
         # cryostat inner and outer walls
@@ -296,7 +296,7 @@ class SANDBuilder(gegede.builder.Builder):
             pla=geom.structure.Placement(name+"_pla",
                                             volume=lv,
                                             pos=pos)
-            print("appending "+pla.name)
+            print(("appending "+pla.name))
             main_lv.placements.append(pla.name)
 
 
@@ -324,7 +324,7 @@ class SANDBuilder(gegede.builder.Builder):
         pla=geom.structure.Placement(name+"_pla",
                                      volume=lv,
                                      pos=pos)
-        print("appending "+pla.name)
+        print(("appending "+pla.name))
         main_lv.placements.append(pla.name)
 
 
@@ -352,7 +352,7 @@ class SANDBuilder(gegede.builder.Builder):
         pla=geom.structure.Placement(name+"_pla",
                                      volume=lv,
                                      pos=pos)
-        print("appending "+pla.name)
+        print(("appending "+pla.name))
         main_lv.placements.append(pla.name)
 
     def build_ecal(self, main_lv, geom):
@@ -417,7 +417,7 @@ class SANDBuilder(gegede.builder.Builder):
                 #print( "Setting 3DST Bfield to "+str(BField))
                 #a3dst_lv.params.append(("BField",BField))
                 
-                print("Working on ", a3dst_lv.name)
+                print(("Working on ", a3dst_lv.name))
                 pos_name = self.name + a3dst_lv.name + '_pos'
                 pla_name = self.name + a3dst_lv.name + '_pla'
                 print(("Position name", pos_name))
@@ -529,8 +529,8 @@ class SANDBuilder(gegede.builder.Builder):
         if "KLOESTT" not in self.builders:
             print("we have a KLOESTT builder key")
             stt_builder=self.get_builder("KLOESTT")
-            print("self.BuildSTT=={}".format(self.BuildSTT))
-            print("stt_builder: {}".format(stt_builder))
+            print(("self.BuildSTT=={}".format(self.BuildSTT)))
+            print(("stt_builder: {}".format(stt_builder)))
             if (stt_builder!=None):
                 rot = [Q("0deg"),Q("90deg"),Q("0deg")]
                 loc = [Q('0m'),Q('0m'),Q('0m')]
@@ -548,8 +548,8 @@ class SANDBuilder(gegede.builder.Builder):
         if "KLOEGAR" not in self.builders:
             print("we have a KLOEGAR builder key")
             gar_builder=self.get_builder("KLOEGAR")
-            print("self.BuildGAR=={}".format(self.BuildGAR))
-            print("gar_builder: {}".format(gar_builder))
+            print(("self.BuildGAR=={}".format(self.BuildGAR)))
+            print(("gar_builder: {}".format(gar_builder)))
             if (gar_builder!=None) and (self.BuildGAR==True):
                 rot = [Q("0deg"),Q("0deg"),Q("0deg")]
                 loc = [Q('0m'),Q('0m'),Q('0m')]
@@ -572,7 +572,7 @@ class SANDBuilder(gegede.builder.Builder):
         pla=geom.structure.Placement(name+"_pla",
                                      volume=lv,
                                      pos=pos)
-        print( "appending "+pla.name)
+        print(( "appending "+pla.name))
 
         main_lv.placements.append(pla.name)
 

--- a/duneggd/SubDetector/STT.py
+++ b/duneggd/SubDetector/STT.py
@@ -30,7 +30,7 @@ class STTBuilder(gegede.builder.Builder):
         self.liqArThickness         = liqArThickness
         self.configuration          = configuration
 
-        print(" ----> self.configuration : ",configuration)
+        print((" ----> self.configuration : ",configuration))
         print()
         self.strawRadius            = Q('2.5mm')
         self.strawWireWThickness    = Q('20um')
@@ -73,13 +73,13 @@ class STTBuilder(gegede.builder.Builder):
         # the gap between the trkMod and CMod is 4.67 instead of 4.67*2
         
 
-        print("trkModThickness  ", self.trkModThickness)
-        print("totfoilThickness:",self.totfoilThickness)
-        print("self.slabThickness:",self.slabThickness)
-        print("planeXXThickness:",self.planeXXThickness)
-        print("C3H6ModThickness:",self.C3H6ModThickness)
-        print("cModThickness:",self.cModThickness)
-        print("--------- liqArThickness -----------:",self.liqArThickness)
+        print(("trkModThickness  ", self.trkModThickness))
+        print(("totfoilThickness:",self.totfoilThickness))
+        print(("self.slabThickness:",self.slabThickness))
+        print(("planeXXThickness:",self.planeXXThickness))
+        print(("C3H6ModThickness:",self.C3H6ModThickness))
+        print(("cModThickness:",self.cModThickness))
+        print(("--------- liqArThickness -----------:",self.liqArThickness))
 
        # GRAIN
         self.HoneycombThickness  = Q("50mm")
@@ -180,8 +180,8 @@ class STTBuilder(gegede.builder.Builder):
         self.SymStopFirstModId=63
         self.STTUpperLength = 27 * self.C3H6ModThickness + 3.5 * self.cModThickness + 2 * self.trkModThickness
         self.realDistance2ECAL= self.kloeTrkRegRadius - self.STTUpperLength
-        print(" STTUpperLength:", self.STTUpperLength)
-        print("  self.realDistance2ECAL:", self.realDistance2ECAL)
+        print((" STTUpperLength:", self.STTUpperLength))
+        print(("  self.realDistance2ECAL:", self.realDistance2ECAL))
 
     def construct_option2(self,geom):
 
@@ -194,8 +194,8 @@ class STTBuilder(gegede.builder.Builder):
         self.SymStopFirstModId=58
         self.STTUpperLength = 25 * self.C3H6ModThickness + 3.5 * self.cModThickness + 2 * self.trkModThickness
         self.realDistance2ECAL= self.kloeTrkRegRadius - self.STTUpperLength
-        print(" STTUpperLength:", self.STTUpperLength)
-        print("  self.realDistance2ECAL:", self.realDistance2ECAL)
+        print((" STTUpperLength:", self.STTUpperLength))
+        print(("  self.realDistance2ECAL:", self.realDistance2ECAL))
 
     def build_STTSegment(self, geom):
 
@@ -211,7 +211,7 @@ class STTBuilder(gegede.builder.Builder):
 
         main_lv = geom.structure.Volume('STTtracker',   material=self.Material, shape=stt_shape)
         print( "KLOESTTFULL::construct()")
-        print( "  main_lv = "+ main_lv.name)
+        print(( "  main_lv = "+ main_lv.name))
         self.add_volume( main_lv )
         return main_lv
 
@@ -223,7 +223,7 @@ class STTBuilder(gegede.builder.Builder):
             name="STT_"+str(imod).zfill(2)+"_"+self.mod_list[imod]
             self.construct_one_module(main_lv, geom, name, self.Material, self.mod_list[imod], left2upstream)
             #print("name:  %s  left2upstream:  %f"%(name,left2upstream));
-            print("name:", name,"  left2upstream:",left2upstream);
+            print(("name:", name,"  left2upstream:",left2upstream));
             left2upstream +=  self.modthicknesses[self.mod_list[imod]]
 
 
@@ -236,14 +236,14 @@ class STTBuilder(gegede.builder.Builder):
             #            j=80-i
             name="STT_"+str(i).zfill(2)+"_"+self.mod_list[i]
             
-            print("name:", name, " l1:",Q("2m")-left2center," l2:", Q("2m")+left2center-ModThickness,"  ModThickness:",ModThickness);
+            print(("name:", name, " l1:",Q("2m")-left2center," l2:", Q("2m")+left2center-ModThickness,"  ModThickness:",ModThickness));
             self.construct_2sym_modules(main_lv,geom, name, self.Material, self.mod_list[i], left2center)
 
 
         imod=self.centralModId
         left2upstream=self.kloeTrkRegRadius- self.cModThickness/2
         name="STT_"+str(imod).zfill(2)+"_"+self.mod_list[imod]
-        print(" name: ",name,"  left2upstream", left2upstream);
+        print((" name: ",name,"  left2upstream", left2upstream));
         self.construct_one_module(main_lv, geom, name, self.Material, self.mod_list[imod], left2upstream)
 
 
@@ -252,7 +252,7 @@ class STTBuilder(gegede.builder.Builder):
             name="STT_"+str(i).zfill(2)+"_"+self.mod_list[i]
             self.construct_one_module(main_lv, geom, name, self.Material, self.mod_list[i], left2upstream)
             #print("name:  %s  left2upstream:  %f"%(name,left2upstream));
-            print("name:", name,"  left2upstream:",left2upstream);
+            print(("name:", name,"  left2upstream:",left2upstream));
             left2upstream += self.modthicknesses[self.mod_list[i]]
 
 
@@ -485,7 +485,7 @@ class STTBuilder(gegede.builder.Builder):
 
         Nstraw=int((2*halfCrosslength-self.strawRadius)/self.strawRadius/2.0)
 
-        print("%s %d %f"%(name,Nstraw*2, (halflength*2).magnitude))
+        print(("%s %d %f"%(name,Nstraw*2, (halflength*2).magnitude)))
 
 
         straw_shape = geom.shapes.Tubs("shape_"+name+"_1st", rmin=Q("0m"), rmax=self.strawRadius, dz=halflength)

--- a/duneggd/SubDetector/STTFULL.py
+++ b/duneggd/SubDetector/STTFULL.py
@@ -60,7 +60,7 @@ class STTFULLBuilder(gegede.builder.Builder):
                 
         main_lv, main_hDim = ltools.main_lv( self, geom, "Tubs")
         print( "KLOESTTFULL::construct()")
-        print( "  main_lv = "+ main_lv.name)
+        print(( "  main_lv = "+ main_lv.name))
         self.add_volume( main_lv )
         
         # LAr target
@@ -121,7 +121,7 @@ class STTFULLBuilder(gegede.builder.Builder):
             
         end_time=tm.time()
         elapsed_time = end_time-start_time
-        print("elapsed time:" + str(elapsed_time))
+        print(("elapsed time:" + str(elapsed_time)))
 
     #^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^
     # construct LAr target
@@ -197,7 +197,7 @@ class STTFULLBuilder(gegede.builder.Builder):
                                         shape=main_shape)
 
         print( "STTModuleFULL::construct()")
-        print( "  main_lv = "+ main_lv.name)
+        print(( "  main_lv = "+ main_lv.name))
 
         foil_lv= self.construct_Foils(geom, 
                                       name + "_foils",
@@ -248,7 +248,7 @@ class STTFULLBuilder(gegede.builder.Builder):
                                         shape=main_shape)
 
         print( "STTModuleFULL::construct()")
-        print( "  main_lv = "+ main_lv.name)
+        print(( "  main_lv = "+ main_lv.name))
 
         slab_shape = geom.shapes.Box(name + "_slab_shape", 
                                      dx=self.slabThickness/2.0, 
@@ -318,7 +318,7 @@ class STTFULLBuilder(gegede.builder.Builder):
                                         shape=main_shape)
         
         print( "STTModuleFULL::construct()")
-        print( "  main_lv = "+ main_lv.name)
+        print(( "  main_lv = "+ main_lv.name))
 
         graphite_shape = geom.shapes.Box(name+"_graph_shape", 
                                          dx=self.graphiteThickness/2.0, 
@@ -371,7 +371,7 @@ class STTFULLBuilder(gegede.builder.Builder):
                                         shape=main_shape)
 
         print( "STTModuleFULL::construct()")
-        print( "  main_lv = "+ main_lv.name)
+        print(( "  main_lv = "+ main_lv.name))
         
         foil_shape = geom.shapes.Box(name + "_foil_shape", 
                                      dx=self.foilThickness/2.0, 

--- a/duneggd/SubDetector/STTFULL2.py
+++ b/duneggd/SubDetector/STTFULL2.py
@@ -10,7 +10,7 @@ class STTFULLBuilder(gegede.builder.Builder):
 
         self.sqrt3                    = 1.7320508
         self.start_time=time.time()
-        print("start_time:",self.start_time)
+        print(("start_time:",self.start_time))
         self.halfDimension, self.Material = ( halfDimension, Material )
 
         self.strawRadius            = Q('2.5mm')
@@ -55,16 +55,16 @@ class STTFULLBuilder(gegede.builder.Builder):
         self.endgap= self.kloeTrkRegRadius*2 - self.liqArThickness - self.totModsThickness
 
         
-        print("endgap:",self.endgap)
-        print("totfoilThickness:",self.totfoilThickness)
-        print("self.slabThickness:",self.slabThickness)
-        print("planeXXThickness:",self.planeXXThickness)
-        print("C3H6ModThickness:",self.C3H6ModThickness)
-        print("cModThickness:",self.cModThickness)
-        print("noSlabModThickness:",self.noSlabModThickness)
-        print("fvModsThickness:",self.fvModsThickness)
-        print("totModsThickness:",self.totModsThickness)
-        print("liqArThickness:",self.liqArThickness)
+        print(("endgap:",self.endgap))
+        print(("totfoilThickness:",self.totfoilThickness))
+        print(("self.slabThickness:",self.slabThickness))
+        print(("planeXXThickness:",self.planeXXThickness))
+        print(("C3H6ModThickness:",self.C3H6ModThickness))
+        print(("cModThickness:",self.cModThickness))
+        print(("noSlabModThickness:",self.noSlabModThickness))
+        print(("fvModsThickness:",self.fvModsThickness))
+        print(("totModsThickness:",self.totModsThickness))
+        print(("liqArThickness:",self.liqArThickness))
         
     def construct(self,geom):
 
@@ -91,7 +91,7 @@ class STTFULLBuilder(gegede.builder.Builder):
         ############################## the main tube    #######################################
         main_lv, main_hDim = ltools.main_lv( self, geom, "Tubs")
         print( "KLOESTTFULL::construct()")
-        print( "  main_lv = "+ main_lv.name)
+        print(( "  main_lv = "+ main_lv.name))
         self.add_volume( main_lv )
 
         ########################################  liq Argon #################################
@@ -139,8 +139,8 @@ class STTFULLBuilder(gegede.builder.Builder):
         
         nModule=1
         for imod in range(nModule):
-            print("### imod ### ",imod)
-            print("### type ### ",mod_types[imod])
+            print(("### imod ### ",imod))
+            print(("### type ### ",mod_types[imod]))
             ModThickness= modthicknesses[mod_types[imod]]
             loc=[usedLength - self.kloeTrkRegRadius + 0.5 * ModThickness,Q("0cm"),Q("0cm")]
             if (usedLength+0.5 * ModThickness) < self.kloeTrkRegRadius:
@@ -162,7 +162,7 @@ class STTFULLBuilder(gegede.builder.Builder):
             usedLength += ModThickness
 #            print("%2d %8s %10.3f %10.3f"%(imod,mod_types[imod],(usedLength-ModThickness).magnitude,usedLength.magnitude))
         end_time=time.time()
-        print("time diff:",end_time-self.start_time)
+        print(("time diff:",end_time-self.start_time))
 
 
     def construct_LAr_target(self,main_lv,geom):
@@ -295,7 +295,7 @@ class STTFULLBuilder(gegede.builder.Builder):
         twoStraw_lv.placements.append(straw2_pla.name)
 
         
-        print("Nstraw",Nstraw)
+        print(("Nstraw",Nstraw))
 
         for i in range(Nstraw):
             pos1=geom.structure.Position("pos_"+name+"_"+str(i), -self.planeXXThickness/2.0+self.strawRadius, halfCrosslength - (2*i+2)*self.strawRadius, Q('0m'))

--- a/duneggd/SubDetector/STTFULL_aug20.py
+++ b/duneggd/SubDetector/STTFULL_aug20.py
@@ -63,14 +63,14 @@ class STTFULLBuilder(gegede.builder.Builder):
         self.endgap= self.kloeTrkRegRadius*2 - self.liqArThickness - self.totModsThickness
 
 
-        print("endgap:",self.endgap)
-        print("totfoilThickness:",self.totfoilThickness)
-        print("self.slabThickness:",self.slabThickness)
-        print("planeXXThickness:",self.planeXXThickness)
-        print("C3H6ModThickness:",self.C3H6ModThickness)
-        print("cModThickness:",self.cModThickness)
-        print("totModsThickness:",self.totModsThickness)
-        print("liqArThickness:",self.liqArThickness)
+        print(("endgap:",self.endgap))
+        print(("totfoilThickness:",self.totfoilThickness))
+        print(("self.slabThickness:",self.slabThickness))
+        print(("planeXXThickness:",self.planeXXThickness))
+        print(("C3H6ModThickness:",self.C3H6ModThickness))
+        print(("cModThickness:",self.cModThickness))
+        print(("totModsThickness:",self.totModsThickness))
+        print(("liqArThickness:",self.liqArThickness))
         
 
     def construct(self,geom):
@@ -136,7 +136,7 @@ class STTFULLBuilder(gegede.builder.Builder):
         stt_shape=geom.shapes.PolyhedraRegular("shape_stt",numsides=24, rmin=Q('0cm'), rmax=self.kloeVesselRadius , dz=self.kloeVesselHalfDx)
         main_lv = geom.structure.Volume('STTtracker',   material=self.Material, shape=stt_shape)
         print( "KLOESTTFULL::construct()")
-        print( "  main_lv = "+ main_lv.name)
+        print(( "  main_lv = "+ main_lv.name))
         self.add_volume( main_lv )
 
         #        test_shape=geom.shapes.PolyhedraRegular("shape_test",numsides=24, rmin=self.kloeVesselRadius, rmax=self.kloeVesselRadius+Q("10cm"), dz=self.kloeVesselHalfDx)
@@ -421,7 +421,7 @@ class STTFULLBuilder(gegede.builder.Builder):
         
         Nstraw=int((2*halfCrosslength-self.strawRadius)/self.strawRadius/2.0)
 
-        print("%s %d %f"%(name,Nstraw*2, (halflength*2).magnitude))
+        print(("%s %d %f"%(name,Nstraw*2, (halflength*2).magnitude)))
         
         return main_lv
         straw_shape = geom.shapes.Tubs("shape_"+name+"_1st", rmin=Q("0m"), rmax=self.strawRadius, dz=halflength)

--- a/duneggd/SubDetector/SandECal.py
+++ b/duneggd/SubDetector/SandECal.py
@@ -114,7 +114,7 @@ class SandECalBuilder(gegede.builder.Builder):
                 'ECAL_rotation' + '_' + str(j), Q('90deg'), -theta * Q('1deg'),
                 Q('0deg'))  #Rotating the module on its axis accordingly
 
-            print("Building Kloe ECAL module " + str(j))  # keep compatibility with Python3 pylint: disable=superfluous-parens
+            print(("Building Kloe ECAL module " + str(j)))  # keep compatibility with Python3 pylint: disable=superfluous-parens
 
             ####Placing and appending the j ECAL Module#####
 
@@ -162,7 +162,7 @@ class SandECalBuilder(gegede.builder.Builder):
             ECAL_end_position = geom.structure.Position(
                 'ECAL_end_position' + '_' + str(side), pos[0], pos[1], pos[2])
 
-            print("Building Kloe ECAL Endcap module " + str(side))  # keep compatibility with Python3 pylint: disable=superfluous-parens
+            print(("Building Kloe ECAL Endcap module " + str(side)))  # keep compatibility with Python3 pylint: disable=superfluous-parens
 
             ########################################################################################
             ECAL_end_place = geom.structure.Placement("ECAL_end_pla" + '_' +

--- a/duneggd/SubDetector/SimpleSubDetector.py
+++ b/duneggd/SubDetector/SimpleSubDetector.py
@@ -36,4 +36,4 @@ class SimpleSubDetectorBuilder(gegede.builder.Builder):
                 TranspV = self.TranspV
             ltools.placeBuilders( self, geom, main_lv, TranspV )
         else:
-            print( "**Warning, no Elements to place inside "+ self.name)
+            print(( "**Warning, no Elements to place inside "+ self.name))


### PR DESCRIPTION
Newer version of gegede only support Python3, and Python2 has been deprecated for a long time now. So future versions of dunendggd should probably switch too.

I just ran `2to3` on everything to make the switch and it seems to work fine.