### PR TITLE
Hack the jsroot sidebar.

### DIFF
--- a/jsroot/jsroot.htm
+++ b/jsroot/jsroot.htm
@@ -4,6 +4,15 @@
       <meta charset="utf-8">
       <title>Read a ROOT file</title>
       <link rel="shortcut icon" href="img/RootIcon.ico"/>
+      <!-- Some hacks for the side bar -->
+      <style>
+          .gui_selectFileName {
+              width: 195px;
+          }
+          #gui_fileCORS small {
+              display: none;
+          }
+      </style>
    </head>
    <body>
       <div id="simpleGUI" path="./" files="nd_hall_with_lar_tms_sand.root;anti_fiducial_nd_hall_with_lar_tms_sand.root">


### PR DESCRIPTION
This should fix #36. Bad hack with CSS attributes. The link to the documentation is JSROOT's own, so I just hid it.