### PR TITLE
Add ndlar only config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Geometry releases will be tagged as `Descriptive_tag_v_X.Y.Z`.
 - Define default geometries in Makefile instead of bash script
 - Implementation of the C-shaped volumes of the SAND ECAL Endcaps
 - Change the NDLAr SensDet name from `TPCActive_shape` and `volTPCActive` to avoid inconsistency between prototype gdml and downstream configuration confusion
+- Add ND-LAr only gdml configuration
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Geometry releases will be tagged as `Descriptive_tag_v_X.Y.Z`.
 - Bump gegede to version 0.8.0
 - Define default geometries in Makefile instead of bash script
 - Implementation of the C-shaped volumes of the SAND ECAL Endcaps
+- Change the NDLAr SensDet name from `TPCActive_shape` and `volTPCActive` to avoid inconsistency between prototype gdml and downstream configuration confusion
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ sandopt: SAND_opt1_STT1.gdml \
 	only_SAND_STT_Initial.gdml \
 	only_SAND_STT_Complete.gdml
 
+lar_only: nd_hall_with_lar_only.gdml
+
 clean:
 	rm *.gdml
 
@@ -65,6 +67,13 @@ anti_fiducial_nd_hall_with_lar_tms_sand.gdml: duneggd/Config/WORLDggd.cfg \
 	duneggd/Config/TMS.cfg \
 	duneggd/Config/ArgonCube/ArgonCubeCryostat.cfg \
 	duneggd/Config/ArgonCube/ArgonCubeDetectorNoActive.cfg
+
+nd_hall_with_lar_only.gdml: duneggd/Config/WORLDggd.cfg \
+        duneggd/Config/ND_Hall_Air_Volume_Only_LArDet.cfg \
+        duneggd/Config/ND_Hall_Rock.cfg \
+        duneggd/Config/ND_CryoStruct.cfg \
+        duneggd/Config/ArgonCube/ArgonCubeCryostat.cfg \
+        duneggd/Config/ArgonCube/ArgonCubeDetector.cfg
 
 nd_hall_with_lar_tms_nosand.gdml: duneggd/Config/WORLDggd.cfg \
 	duneggd/Config/ND_Hall_Air_Volume_LAr_TMS_noSAND.cfg \

--- a/duneggd/ArgonCube/TPC.py
+++ b/duneggd/ArgonCube/TPC.py
@@ -66,7 +66,7 @@ class TPCBuilder(gegede.builder.Builder):
                                         material=self.Material,
                                         shape=TPCActive_shape)
 
-        TPCActive_lv.params.append(("SensDet","TPCActive_shape"))
+        TPCActive_lv.params.append(("SensDet","volTPCActive"))
         TPCActive_lv.params.append(("EField","(500.0 V/cm, 0.0 V/cm, 0.0 V/cm)"))
 
         # Place TPCActive

--- a/duneggd/Config/ND_Hall_Air_Volume_Only_LArDet.cfg
+++ b/duneggd/Config/ND_Hall_Air_Volume_Only_LArDet.cfg
@@ -1,0 +1,77 @@
+[ND_Hall_Air_Volume]
+
+class = duneggd.Hall.ND_Hall_Air_Volume.NDHallAirVolumeBuilder
+
+#With detectors
+subbuilders = ['ArgonCubeDetector', 'ND_CryoStruct']
+
+
+#After rotating - with detectors 
+Positions = [ [Q('17984mm'), Q('-2.745m'), Q('-2.94m')],
+              [Q('50.89mm'), Q('-3536.67mm'), Q('-7842.6mm')]
+            ]
+
+#After rotating - with detectors
+Rotations = [ [Q('0deg'), Q('0deg'), Q('0deg')],
+              [Q('0deg'), Q('-90deg'), Q('0deg')]
+            ]
+
+#After rotating - without detectors
+#Positions = [ [Q('-26972.4mm'), Q('4.595m'), Q('0m')],
+#              [Q('0m'), Q('4637.2mm'), Q('9396.8mm')],
+#              [Q('0m'), Q('4637.2mm'), Q('-9396.8mm')],
+#              [Q('0m'), Q('-5945.18mm'), Q('-8685.6mm')],
+#              [Q('50.89mm'), Q('-3536.67mm'), Q('-7842.6mm')]
+#            ]
+
+#After rotating - without detectors
+#Rotations = [ [Q('0deg'), Q('-90deg'), Q('0deg')],
+#              [Q('0deg'), Q('-90deg'), Q('0deg')],
+#              [Q('0deg'), Q('90deg'), Q('0deg')],
+#              [Q('0deg'), Q('-90deg'), Q('0deg')],
+#              [Q('0deg'), Q('-90deg'), Q('0deg')]
+#            ]
+
+mat = 'Air'
+
+#NDHallSpace1Dim = [Q('19.20m'), Q('15.24m'), Q('49.38m')]
+
+#NDHallSpace2Dim = [Q('10.35m'), Q('10.64m'), Q('9.62m')]
+#NDHallSpace2Pos = [Q('-14.775m'), Q('-2.3m'), Q('18484.8mm')]
+
+#NDHallSpace3Dim = [Q('0m'), Q('5.79m'), Q('24.43m'), Q('0deg'), Q('360deg')]
+#NDHallSpace3Pos = [Q('0m'), Q('4.595m'), Q('-24.69m')] #0, 4.595m, -24.59m
+
+#NDHallSpace4Dim = [Q('0m'), Q('10401.3mm'), Q('49.39m'), Q('22.63966deg'), Q('134.721deg')]
+#NDHallSpace4Pos = [Q('0m'), Q('3616.62mm'), Q('0m')]
+
+#NDHallSpace5Dim = [Q('304.80mm'), Q('2438.40mm'), Q('914.40mm')]
+#NDHallSpace5Pos = [Q('9752.4mm'), Q('-6400.8mm'), Q('3352.8mm')]
+
+#NDHallSpace6Dim = [Q('2133.60mm'), Q('7620.00mm'), Q('3657.60mm')]
+#NDHallSpace6Pos = [Q('7842.60mm'), Q('-304.55mm'), Q('-26518.8mm')]
+
+#NDHallSpace7Dim = [Q('2287.02mm'), Q('4267.20mm'), Q('1524.00mm')]
+#NDHallSpace7Pos = [Q('5632.3mm'), Q('1371.80mm'), Q('-27585.60mm')]
+
+NDHallSpace1Dim = [Q('49.38m'), Q('15.24m'), Q('19.20m')]
+
+NDHallSpace2Dim = [Q('9.62m'), Q('10.64m'), Q('10.35m')]
+NDHallSpace2Pos = [Q('18484.8mm'), Q('-2.3m'), Q('14.775m')]
+
+NDHallSpace3Dim = [Q('0m'), Q('5.79m'), Q('24.43m'), Q('0deg'), Q('360deg')]
+NDHallSpace3Pos = [Q('-24.69m'), Q('4.595m'), Q('0m')] #-24.69m, 4.595m, 0
+
+NDHallSpace4Dim = [Q('0m'), Q('10401.3mm'), Q('49.39m'), Q('22.63966deg'), Q('134.721deg')]
+NDHallSpace4Pos = [Q('0m'), Q('3616.62mm'), Q('0m')]
+
+NDHallSpace5Dim = [Q('914.40mm'), Q('2438.40mm'), Q('304.80mm')]
+NDHallSpace5Pos = [Q('3352.8mm'), Q('-6400.8mm'), Q('-9752.4mm')]
+
+NDHallSpace6Dim = [Q('3657.60mm'), Q('7620.00mm'), Q('2133.60mm')]
+NDHallSpace6Pos = [Q('-26518.8mm'), Q('-304.55mm'), Q('-7842.60mm')]
+
+NDHallSpace7Dim = [Q('1524.00mm'), Q('4267.20mm'), Q('2287.02mm')]
+NDHallSpace7Pos = [Q('-27585.60mm'), Q('1371.80mm'), Q('-5632.3mm')]
+
+


### PR DESCRIPTION
Adding ndlar only configuration, checked that the detector position matches with [nd_hall_with_lar_tms_sand_TDR_Production_geometry_v_1.0.3.gdml](https://github.com/DUNE/2x2_sim/blob/develop/geometry/nd_hall_with_lar_tms_sand_TDR_Production_geometry_v_1.0.3.gdml) and there is no overlap in the geometry. This gdml is tested to generate edepsim events.

Note that this PR is built on PR #41 , so the LAr SensDet name is changed in this PR too.

Tagging @alexbooth92 @diaza @mjkramer , in case anyone has a comment.