### PR TITLE
Fix rock density

### DIFF
--- a/duneggd/LocalTools/materialdefinition.py
+++ b/duneggd/LocalTools/materialdefinition.py
@@ -56,19 +56,17 @@ def define_materials( g ):
     TiO2  = g.matter.Molecule("TiO2",  density="4.23*g/cc",  elements=(("titanium",1),("oxygen",2)))
     Fe2O3 = g.matter.Molecule("Fe2O3", density="5.24*g/cc",  elements=(("iron",2),("oxygen",3)))
 
-    rock  = g.matter.Mixture( "Rock", density = "2.82*g/cc",
+    rock  = g.matter.Mixture( "Rock", density = "2.33*g/cc",
                             components = (
-                               ("SiO2",   0.5267),
-                               ("FeO",    0.1174),
-                               ("Al2O3",  0.1025),
-                               ("oxygen", 0.0771),
-                               ("MgO",    0.0473),
-                               ("CO2",    0.0422),
-                               ("CaO",    0.0382),
-                               ("carbon", 0.0240),
-                               ("sulfur", 0.0186),
-                               ("Na2O",   0.0053),
-                               ("P2O5",   0.0007),
+                                ("hydrogen",    0.0147547),
+                                ("carbon",      0.0114328),
+                                ("oxygen",      0.0431255),
+                                ("calcium",     0.0431250),
+                                ("sodium",      0.0028548),
+                                ("aluminum",    0.0946920),
+                                ("iron",        0.0179492),
+                                ("silicon",     0.2420140),
+                                ("potassium",   0.0093778),
                             ))
 
     dirt  = g.matter.Mixture( "Dirt", density = "1.7*g/cc",


### PR DESCRIPTION
@diaza pointed out that the rock density of the ND cavern for 2x2 is wrong. The ND-LAr cavern will be very similar. So this updates the rock density to match. See [this conversation](https://dunescience.slack.com/archives/CKXSC8EG3/p1738692609505719).

## Does this affect the rock muon rate?
> The difference in density of the rock isn’t quite as important as it might look initially.   This is because while at the higher density there’s more interactions in the rock, there’s also more attenuation of the events due to ranging out.   They don’t exactly cancel out 100% but the effect isn’t 2.82/2.33=1.21 - R. Hatcher

## What's the source of the difference?
> iirc, 2.82 is the dry density of the crushed rock, and 2.33 accounts for the porous wet rock. Some percentage of the rock is filled with water which decreases the avg density - me

## New Parameters:
``` xml
<D value="2.33" unit="g/cm3"/>
<fraction n="0.0147547" ref="Hydrogen"/>
<fraction n="0.0114328" ref="Carbon"  />
<fraction n="0.5637993" ref="Oxygen"  />
<fraction n="0.0431255" ref="Calcium" />
<fraction n="0.0028548" ref="Sodium"  />
<fraction n="0.0946920" ref="Aluminum"/>
<fraction n="0.0179492" ref="Iron"    />
<fraction n="0.2420140" ref="Silicon" />
<fraction n="0.0093778" ref="Potassium"/>
```