### PR TITLE
Add git version metadata to volWorld

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # We need the full history for the git metadata
     - name: Setup
       run: pip install .
     - name: Build default gdml files

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # We need the full history for the git metadata
     - name: Setup
       run: pip install .
     - name: Build defaul gdml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Geometry releases will be tagged as `Descriptive_tag_v_X.Y.Z`.
 ### Added
 
 - Check for CHANGELOG update in PRs
+- Versioning metadata to `volWorld`: `git_commit`, `git_branch`, and `git_tag`
 
 ## [TDR_Production_geometry_v_1.1.0]
 

--- a/duneggd/World.py
+++ b/duneggd/World.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from subprocess import run
 import gegede.builder
 from duneggd.LocalTools import localtools as ltools
 from duneggd.LocalTools import materialdefinition as materials
@@ -13,6 +14,25 @@ class WorldBuilder(gegede.builder.Builder):
         self.Material = Material
         self.RockPosition = RockPosition
         self.RockRotation = RockRotation
+
+        # Get current git commit hash
+        ret = run(["git", "rev-parse", "HEAD"], capture_output=True, text=True)
+        if ret.returncode == 0:
+            self.git_commit = ret.stdout.strip()
+            # Get current tag
+            ret = run(["git", "describe", "--tags", "HEAD"], capture_output=True, text=True)
+            self.git_tag = ret.stdout.strip()
+            # Get current branch
+            ret = run(["git", "rev-parse", "--abbrev-ref", "HEAD"], capture_output=True, text=True)
+            self.git_branch = ret.stdout.strip()
+        else:
+            # Error in calling `git`
+            self.git_commit = ""
+            self.git_tag = ""
+            self.git_branch = ""
+        print(f"Current git commit: {self.git_commit}")
+        print(f"Current git branch: {self.git_branch}")
+        print(f"Current git tag:    {self.git_tag}")
     #^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^
     def construct(self, geom):
 
@@ -53,3 +73,8 @@ class WorldBuilder(gegede.builder.Builder):
         Rock_rot = geom.structure.Rotation(de_lv.name+'_rot', rot[0], rot[1], rot[2])
         Rock_pla = geom.structure.Placement(de_lv.name+'_pla', volume=de_lv, pos=Rock_pos,rot=Rock_rot)
         main_lv.placements.append(Rock_pla.name)
+
+        # Add metadata
+        main_lv.params.append(("git_commit", self.git_commit))
+        main_lv.params.append(("git_branch", self.git_branch))
+        main_lv.params.append(("git_tag", self.git_tag))

--- a/duneggd/World.py
+++ b/duneggd/World.py
@@ -4,6 +4,7 @@ import gegede.builder
 from duneggd.LocalTools import localtools as ltools
 from duneggd.LocalTools import materialdefinition as materials
 from gegede import Quantity as Q
+import sys
 
 
 #Changed DetEnc to Rock
@@ -30,9 +31,16 @@ class WorldBuilder(gegede.builder.Builder):
             self.git_commit = ""
             self.git_tag = ""
             self.git_branch = ""
+
+        # Get output file name
+        self.output_file_name = ""
+        if "-o" in sys.argv:
+            self.output_file_name = sys.argv[sys.argv.index('-o') + 1]
+
         print(f"Current git commit: {self.git_commit}")
         print(f"Current git branch: {self.git_branch}")
         print(f"Current git tag:    {self.git_tag}")
+        print(f"Output file name:   {self.output_file_name}")
     #^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^
     def construct(self, geom):
 
@@ -78,3 +86,4 @@ class WorldBuilder(gegede.builder.Builder):
         main_lv.params.append(("git_commit", self.git_commit))
         main_lv.params.append(("git_branch", self.git_branch))
         main_lv.params.append(("git_tag", self.git_tag))
+        main_lv.params.append(("output_file_name", self.output_file_name))


### PR DESCRIPTION
Adds some metadata to `volWorld`:

- `git_commit`: The full hash of the current commit
- `git_branch`: The name of the current branch
- `git_tag`: The name of the latest tag, plus optionally how many commits have been added since. See [`git describe --tags`](https://git-scm.com/docs/git-describe).