### PR TITLE
Jdkio remove muon tagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Geometry releases will be tagged as `Descriptive_tag_v_X.Y.Z`.
 
 ## [Unreleased]
 
+### Removed
+
+- Muon tagger as it's not in current engineering design
+
 ## [TDR_Production_geometry_v_1.2.0]
 
 ### Changed

--- a/duneggd/Config/ArgonCube/ArgonCubeCryostat.cfg
+++ b/duneggd/Config/ArgonCube/ArgonCubeCryostat.cfg
@@ -258,10 +258,17 @@ dz                   = {MuonTaggerPlanes:dz}
 SubBPos              = [Q('0.5m'), Q('1m'), Q('0mm')]
 NElements            = 0
 
+[EmptyTagger]
+class                = duneggd.Active.RectBar.RectBarBuilder
+Material             = 'Air'
+dx                   = Q('9m')/2
+dy                   = Q('4.5m')/2
+dz                   = Q('1cm')
+
 [ArgonCubeCryostatWithTagger]
 class                = duneggd.SubDetector.ComplexSubDetector.ComplexSubDetectorBuilder
 Material             = 'Air'
-subbuilders          = ['MuonTagger','ArgonCubeCryostat']
+subbuilders          = ['EmptyTagger','ArgonCubeCryostat']
 TranspV              = [0,0,1]
 NElements            = 1
 dx                   = {ArgonCubeCryostat:dx}

--- a/scripts/draw_geometry.py
+++ b/scripts/draw_geometry.py
@@ -547,6 +547,11 @@ def get_default_view(args, view_name, w, h, translate):
         box_max = (800 * ratio, translate, 1400)
         matrix = create_projection_matrix(w, h, box_min, box_max, "XZ")
         projection = "XZ"
+    if view_name == "tagger":
+        box_min = (-800 * ratio, translate, 150)
+        box_max = (800 * ratio, translate, 450)
+        matrix = create_projection_matrix(w, h, box_min, box_max, "XZ")
+        projection = "XZ"
     if view_name == "lar_side":
         box_min = (translate, -800 * ratio, 0)
         box_max = (translate, 400 * ratio, 1200)


### PR DESCRIPTION
In the PDR, it says "muon tagger is not part of the default design" so this gets rid of it. Removes the tagger by replacing it with air with an EmptyTagger object. I tried removing it by bypassing the `ArgonCubeCryostatWithTagger` and going straight to the `ArgonCubeCryostat`, but that moves NDLar by about 0.5cm (see below).

Here are images comparing before and after. This is a X (horizontal axis) vs Z (vertical axis) view. The color tells you the material density. The red, green, and blue on the bottom is LAr and the sliver of green of the far right is the rock wall. The tagger is the sliver on top of the red. You can see it in the before shot:
<img width="250" height="200" alt="tagger_main" src="https://github.com/user-attachments/assets/942d3cea-140f-4c91-9e28-c76dcd1800a7" />

And it's removed in the after shot, and nothing else moves:
<img width="250" height="200" alt="tagger_removed" src="https://github.com/user-attachments/assets/73b5ddea-d273-472a-bba8-0bb3873ee0ac" />

## Note that this doesn't work
```bash
# What about changing 
subbuilders          = ['CryostatSupportStructure','ArgonCubeCryostatWithTagger']
# to
subbuilders          = ['CryostatSupportStructure','ArgonCubeCryostat']
```
You have to download the images and do a slideshow, then you'll see that the cryostate changes position by about 0.5cm, which is half the width of the tagger. So I created the EmptyTagger instead.
<img width="250" height="200" alt="tagger_changing_ArgonCubeCryostatWithTagger" src="https://github.com/user-attachments/assets/a7859751-06c1-4e75-8e7f-2d1685fa38d6" />
