### PR TITLE
Removed polyurethane foam material as it is no longer used in cryostat

### DIFF
--- a/duneggd/Config/ArgonCube/ArgonCubeCryostat.cfg
+++ b/duneggd/Config/ArgonCube/ArgonCubeCryostat.cfg
@@ -132,7 +132,7 @@ dz                   = {LArBath:dz}
 [Membrane]
 class                = duneggd.SubDetector.SimpleSubDetector.SimpleSubDetectorBuilder
 subbuilders          = ['ArgonInner']
-Material             = 'Plywood'
+Material             = 'SSteel304'
 dx                   = {ArgonInner:dx}+Q('1.2mm')
 dy                   = {ArgonInner:dy}+Q('1.2mm')
 dz                   = {ArgonInner:dz}+Q('1.2mm')
@@ -142,7 +142,7 @@ NElements            = 0
 [ThermalInsulation]
 class                = duneggd.SubDetector.SimpleSubDetector.SimpleSubDetectorBuilder
 subbuilders          = ['Membrane']
-Material             = 'PolyurethaneFoam'
+Material             = 'Polyurethane'
 dx                   = {Membrane:dx}+Q('800mm')
 dy                   = {Membrane:dy}+Q('400mm')
 dz                   = {Membrane:dz}+Q('800mm')
@@ -190,11 +190,10 @@ show_cover_sheets = True #covers the front and back, set to false to see the win
 verti_active_area = Q("3285mm") / 2 #uses 3285 not 3030 from diagram, 3030 breaks this.
 hori_active_area = Q("7000mm") / 2
 dz = ( Q("403.19mm")   ) / 2
-AuxParams = {"SensDet":"MuonWindow"}
+
 
 [block]
 class =  duneggd.ArgonCube.dune_window.Block
-AuxParams = {"SensDet":"MuonWindow"}
 material = "SSteel304"
 length = Q("8620mm") / 2
 height = Q("3800mm") / 2

--- a/duneggd/LocalTools/materialdefinition.py
+++ b/duneggd/LocalTools/materialdefinition.py
@@ -376,14 +376,7 @@ def define_materials( g ):
                                 ("oxygen",10)
                             ))
 
-    polyurethanefoam = g.matter.Molecule("PolyurethaneFoam", density="0.090*g/cc",
-                            elements=(
-                                ("carbon",27),
-                                ("hydrogen",36),
-                                ("nitrogen",2),
-                                ("oxygen",10)
-                            ))
-
+    
     # http://www.engineeringtoolbox.com/engineering-materials-properties-d_1225.html
     # http://hepwww.rl.ac.uk/atlas-sct/engineering/material_budget/models/Endcap_Module/ATLAS_ECSCT_Materials.pdf
     # table 3 - C6 H6 O, jp


### PR DESCRIPTION
Removed polyurethane foam material as it is no longer used in cryostat, also removed the auxparam that makes the window sensitive.